### PR TITLE
Modified the way json objects returned by REST API are processed, so now they will be valid json

### DIFF
--- a/src/carrot_cli/pipeline/command.py
+++ b/src/carrot_cli/pipeline/command.py
@@ -1,3 +1,4 @@
+import json
 import logging
 import sys
 

--- a/src/carrot_cli/rest/request_handler.py
+++ b/src/carrot_cli/rest/request_handler.py
@@ -212,11 +212,13 @@ def send_request(method, url, params=None, body=None):
             return (
                 "Received response with status %i and empty body" % response.status_code
             )
-        return pprint.PrettyPrinter().pformat(json_body)
+        return json.dumps(json_body, indent=4, sort_keys=True)
+        #return pprint.PrettyPrinter().pformat(json_body)
     except (AttributeError, json.decoder.JSONDecodeError):
         LOGGER.debug("Failed to parse json from response body: %s", response.text)
-        return pprint.PrettyPrinter().pformat(
-            {"Status": response.status_code, "Body": response.text}
+        return json.dumps(
+            {"Status": response.status_code, "Body": response.text},
+            indent=4, sort_keys=True
         )
     except requests.ConnectionError as err:
         LOGGER.debug(err)

--- a/src/carrot_cli/rest/request_handler.py
+++ b/src/carrot_cli/rest/request_handler.py
@@ -213,12 +213,13 @@ def send_request(method, url, params=None, body=None):
                 "Received response with status %i and empty body" % response.status_code
             )
         return json.dumps(json_body, indent=4, sort_keys=True)
-        #return pprint.PrettyPrinter().pformat(json_body)
+        # return pprint.PrettyPrinter().pformat(json_body)
     except (AttributeError, json.decoder.JSONDecodeError):
         LOGGER.debug("Failed to parse json from response body: %s", response.text)
         return json.dumps(
             {"Status": response.status_code, "Body": response.text},
-            indent=4, sort_keys=True
+            indent=4,
+            sort_keys=True,
         )
     except requests.ConnectionError as err:
         LOGGER.debug(err)

--- a/tests/unit/pipeline/test_pipeline_command.py
+++ b/tests/unit/pipeline/test_pipeline_command.py
@@ -32,7 +32,8 @@ def no_email():
                     "name": "Sword of Protection Pipeline",
                     "pipeline_id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
                 },
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
         {
@@ -43,7 +44,8 @@ def no_email():
                     "status": 404,
                     "detail": "No pipeline found with the specified ID",
                 },
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
     ]
@@ -108,7 +110,8 @@ def test_find_by_id(find_by_id_data):
                     "name": "Sword of Protection Pipeline",
                     "pipeline_id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
                 },
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
         {
@@ -135,7 +138,8 @@ def test_find_by_id(find_by_id_data):
                     "status": 404,
                     "detail": "No pipelines found with the specified parameters",
                 },
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
     ]
@@ -190,7 +194,8 @@ def test_find(find_data):
                     "name": "Sword of Protection Pipeline",
                     "pipeline_id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
                 },
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
         {
@@ -263,7 +268,8 @@ def test_create(create_data, caplog):
                     "name": "New Sword of Protection Pipeline",
                     "pipeline_id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
                 },
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
         {
@@ -300,8 +306,7 @@ def test_update(update_data):
         {
             "args": ["pipeline", "delete", "cd987859-06fe-4b1a-9e96-47d4f36bf819"],
             "return": json.dumps(
-                {"message": "Successfully deleted 1 row"},
-                indent=4, sort_keys=True
+                {"message": "Successfully deleted 1 row"}, indent=4, sort_keys=True
             ),
         },
         {
@@ -312,7 +317,8 @@ def test_update(update_data):
                     "status": 404,
                     "detail": "No pipeline found with the specified ID",
                 },
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
     ]
@@ -403,7 +409,8 @@ def test_delete(delete_data):
                         "run_id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
                     }
                 ],
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
         {
@@ -431,7 +438,8 @@ def test_delete(delete_data):
                     "status": 404,
                     "detail": "No runs found with the specified parameters",
                 },
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
         {
@@ -501,7 +509,8 @@ def test_find_runs(find_runs_data, caplog):
                     "email": "netossa@example.com",
                     "created_at": "2020-09-23T19:41:46.839880",
                 },
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
         {
@@ -522,7 +531,8 @@ def test_find_runs(find_runs_data, caplog):
                     "status": 404,
                     "detail": "No pipeline found with the specified ID",
                 },
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
         {
@@ -536,7 +546,8 @@ def test_find_runs(find_runs_data, caplog):
                     "email": "frosta@example.com",
                     "created_at": "2020-09-23T19:41:46.839880",
                 },
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
     ]
@@ -570,8 +581,7 @@ def test_subscribe(subscribe_data):
             ],
             "params": ["cd987859-06fe-4b1a-9e96-47d4f36bf819", "netossa@example.com"],
             "return": json.dumps(
-                {"message": "Successfully deleted 1 row(s)"},
-                indent=4, sort_keys=True
+                {"message": "Successfully deleted 1 row(s)"}, indent=4, sort_keys=True
             ),
         },
         {
@@ -592,15 +602,15 @@ def test_subscribe(subscribe_data):
                     "status": 404,
                     "detail": "No subscription found for the specified parameters",
                 },
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
         {
             "args": ["pipeline", "unsubscribe", "89657859-06fe-4b1a-9e96-47d4f36bf819"],
             "params": ["89657859-06fe-4b1a-9e96-47d4f36bf819", "frosta@example.com"],
             "return": json.dumps(
-                {"message": "Successfully deleted 1 row(s)"},
-                indent=4, sort_keys=True
+                {"message": "Successfully deleted 1 row(s)"}, indent=4, sort_keys=True
             ),
         },
     ]

--- a/tests/unit/pipeline/test_pipeline_command.py
+++ b/tests/unit/pipeline/test_pipeline_command.py
@@ -1,4 +1,4 @@
-import pprint
+import json
 
 from click.testing import CliRunner
 
@@ -24,24 +24,26 @@ def no_email():
     params=[
         {
             "args": ["pipeline", "find_by_id", "cd987859-06fe-4b1a-9e96-47d4f36bf819"],
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 {
                     "created_at": "2020-09-16T18:48:06.371563",
                     "created_by": "adora@example.com",
                     "description": "This pipeline will save Etheria",
                     "name": "Sword of Protection Pipeline",
                     "pipeline_id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
-                }
+                },
+                indent=4, sort_keys=True
             ),
         },
         {
             "args": ["pipeline", "find_by_id", "cd987859-06fe-4b1a-9e96-47d4f36bf819"],
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 {
                     "title": "No pipeline found",
                     "status": 404,
                     "detail": "No pipeline found with the specified ID",
-                }
+                },
+                indent=4, sort_keys=True
             ),
         },
     ]
@@ -98,14 +100,15 @@ def test_find_by_id(find_by_id_data):
                 1,
                 0,
             ],
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 {
                     "created_at": "2020-09-16T18:48:06.371563",
                     "created_by": "adora@example.com",
                     "description": "This pipeline will save Etheria",
                     "name": "Sword of Protection Pipeline",
                     "pipeline_id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
-                }
+                },
+                indent=4, sort_keys=True
             ),
         },
         {
@@ -126,12 +129,13 @@ def test_find_by_id(find_by_id_data):
                 20,
                 0,
             ],
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 {
                     "title": "No pipelines found",
                     "status": 404,
                     "detail": "No pipelines found with the specified parameters",
-                }
+                },
+                indent=4, sort_keys=True
             ),
         },
     ]
@@ -178,14 +182,15 @@ def test_find(find_data):
                 "This pipeline will save Etheria",
                 "adora@example.com",
             ],
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 {
                     "created_at": "2020-09-16T18:48:06.371563",
                     "created_by": "adora@example.com",
                     "description": "This pipeline will save Etheria",
                     "name": "Sword of Protection Pipeline",
                     "pipeline_id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
-                }
+                },
+                indent=4, sort_keys=True
             ),
         },
         {
@@ -250,14 +255,15 @@ def test_create(create_data, caplog):
                 "New Sword of Protection Pipeline",
                 "This new pipeline replaced the broken one",
             ],
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 {
                     "created_at": "2020-09-16T18:48:06.371563",
                     "created_by": "adora@example.com",
                     "description": "This new pipeline replaced the broken one",
                     "name": "New Sword of Protection Pipeline",
                     "pipeline_id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
-                }
+                },
+                indent=4, sort_keys=True
             ),
         },
         {
@@ -293,18 +299,20 @@ def test_update(update_data):
     params=[
         {
             "args": ["pipeline", "delete", "cd987859-06fe-4b1a-9e96-47d4f36bf819"],
-            "return": pprint.PrettyPrinter().pformat(
-                {"message": "Successfully deleted 1 row"}
+            "return": json.dumps(
+                {"message": "Successfully deleted 1 row"},
+                indent=4, sort_keys=True
             ),
         },
         {
             "args": ["pipeline", "delete", "cd987859-06fe-4b1a-9e96-47d4f36bf819"],
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 {
                     "title": "No pipeline found",
                     "status": 404,
                     "detail": "No pipeline found with the specified ID",
-                }
+                },
+                indent=4, sort_keys=True
             ),
         },
     ]
@@ -378,7 +386,7 @@ def test_delete(delete_data):
                 1,
                 0,
             ],
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 [
                     {
                         "created_at": "2020-09-16T18:48:06.371563",
@@ -394,7 +402,8 @@ def test_delete(delete_data):
                         "test_id": "3d1bfbab-d9ec-46c7-aa8e-9c1d1808f2b8",
                         "run_id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
                     }
-                ]
+                ],
+                indent=4, sort_keys=True
             ),
         },
         {
@@ -416,12 +425,13 @@ def test_delete(delete_data):
                 20,
                 0,
             ],
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 {
                     "title": "No run found",
                     "status": 404,
                     "detail": "No runs found with the specified parameters",
-                }
+                },
+                indent=4, sort_keys=True
             ),
         },
         {
@@ -483,14 +493,15 @@ def test_find_runs(find_runs_data, caplog):
                 "netossa@example.com",
             ],
             "params": ["cd987859-06fe-4b1a-9e96-47d4f36bf819", "netossa@example.com"],
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 {
                     "subscription_id": "361b3b95-4a6e-40d9-bd98-f92b2959864e",
                     "entity_type": "pipeline",
                     "entity_id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
                     "email": "netossa@example.com",
                     "created_at": "2020-09-23T19:41:46.839880",
-                }
+                },
+                indent=4, sort_keys=True
             ),
         },
         {
@@ -505,25 +516,27 @@ def test_find_runs(find_runs_data, caplog):
                 "89657859-06fe-4b1a-9e96-47d4f36bf819",
                 "spinnerella@example.com",
             ],
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 {
                     "title": "No pipeline found",
                     "status": 404,
                     "detail": "No pipeline found with the specified ID",
-                }
+                },
+                indent=4, sort_keys=True
             ),
         },
         {
             "args": ["pipeline", "subscribe", "89657859-06fe-4b1a-9e96-47d4f36bf819"],
             "params": ["89657859-06fe-4b1a-9e96-47d4f36bf819", "frosta@example.com"],
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 {
                     "subscription_id": "361b3b95-4a6e-40d9-bd98-f92b2959864e",
                     "entity_type": "pipeline",
                     "entity_id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
                     "email": "frosta@example.com",
                     "created_at": "2020-09-23T19:41:46.839880",
-                }
+                },
+                indent=4, sort_keys=True
             ),
         },
     ]
@@ -556,8 +569,9 @@ def test_subscribe(subscribe_data):
                 "netossa@example.com",
             ],
             "params": ["cd987859-06fe-4b1a-9e96-47d4f36bf819", "netossa@example.com"],
-            "return": pprint.PrettyPrinter().pformat(
-                {"message": "Successfully deleted 1 row(s)"}
+            "return": json.dumps(
+                {"message": "Successfully deleted 1 row(s)"},
+                indent=4, sort_keys=True
             ),
         },
         {
@@ -572,19 +586,21 @@ def test_subscribe(subscribe_data):
                 "89657859-06fe-4b1a-9e96-47d4f36bf819",
                 "spinnerella@example.com",
             ],
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 {
                     "title": "No subscription found",
                     "status": 404,
                     "detail": "No subscription found for the specified parameters",
-                }
+                },
+                indent=4, sort_keys=True
             ),
         },
         {
             "args": ["pipeline", "unsubscribe", "89657859-06fe-4b1a-9e96-47d4f36bf819"],
             "params": ["89657859-06fe-4b1a-9e96-47d4f36bf819", "frosta@example.com"],
-            "return": pprint.PrettyPrinter().pformat(
-                {"message": "Successfully deleted 1 row(s)"}
+            "return": json.dumps(
+                {"message": "Successfully deleted 1 row(s)"},
+                indent=4, sort_keys=True
             ),
         },
     ]

--- a/tests/unit/report/test_report_command.py
+++ b/tests/unit/report/test_report_command.py
@@ -1,4 +1,4 @@
-import pprint
+import json
 
 from click.testing import CliRunner
 
@@ -24,7 +24,7 @@ def no_email():
     params=[
         {
             "args": ["report", "find_by_id", "cd987859-06fe-4b1a-9e96-47d4f36bf819"],
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 {
                     "created_at": "2020-09-16T18:48:06.371563",
                     "created_by": "adora@example.com",
@@ -86,17 +86,19 @@ def no_email():
                     "config": {"cpu": 2},
                     "name": "Sword of Protection report",
                     "report_id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
-                }
+                },
+                indent=4, sort_keys=True
             ),
         },
         {
             "args": ["report", "find_by_id", "cd987859-06fe-4b1a-9e96-47d4f36bf819"],
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 {
                     "title": "No report found",
                     "status": 404,
                     "detail": "No report found with the specified ID",
-                }
+                },
+                indent=4, sort_keys=True
             ),
         },
     ]
@@ -212,7 +214,7 @@ def test_find_by_id(find_by_id_data):
                 1,
                 0,
             ],
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 {
                     "created_at": "2020-09-16T18:48:06.371563",
                     "created_by": "adora@example.com",
@@ -274,7 +276,8 @@ def test_find_by_id(find_by_id_data):
                     "config": {"cpu": 2},
                     "name": "Sword of Protection report",
                     "report_id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
-                }
+                },
+                indent=4, sort_keys=True
             ),
         },
         {
@@ -297,12 +300,13 @@ def test_find_by_id(find_by_id_data):
                 20,
                 0,
             ],
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 {
                     "title": "No reports found",
                     "status": 404,
                     "detail": "No reports found with the specified parameters",
-                }
+                },
+                indent=4, sort_keys=True
             ),
         },
     ]
@@ -410,7 +414,7 @@ def test_find(find_data):
                 {"cpu": 2},
                 "adora@example.com",
             ],
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 {
                     "created_at": "2020-09-16T18:48:06.371563",
                     "created_by": "adora@example.com",
@@ -472,7 +476,8 @@ def test_find(find_data):
                     "config": {"cpu": 2},
                     "name": "Sword of Protection report",
                     "report_id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
-                }
+                },
+                indent=4, sort_keys=True
             ),
         },
         {
@@ -602,7 +607,7 @@ def test_create(create_data, caplog):
                 },
                 {"cpu": 2},
             ],
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 {
                     "config": {"cpu": 2},
                     "created_at": "2020-09-16T18:48:06.371563",
@@ -664,7 +669,8 @@ def test_create(create_data, caplog):
                         ],
                     },
                     "report_id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
-                }
+                },
+                indent=4, sort_keys=True
             ),
         },
         {
@@ -702,13 +708,13 @@ def test_update(update_data):
     params=[
         {
             "args": ["report", "delete", "cd987859-06fe-4b1a-9e96-47d4f36bf819"],
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 {"message": "Successfully deleted 1 row"}
             ),
         },
         {
             "args": ["report", "delete", "cd987859-06fe-4b1a-9e96-47d4f36bf819"],
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 {
                     "title": "No report found",
                     "status": 404,

--- a/tests/unit/report/test_report_command.py
+++ b/tests/unit/report/test_report_command.py
@@ -87,7 +87,8 @@ def no_email():
                     "name": "Sword of Protection report",
                     "report_id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
                 },
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
         {
@@ -98,7 +99,8 @@ def no_email():
                     "status": 404,
                     "detail": "No report found with the specified ID",
                 },
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
     ]
@@ -277,7 +279,8 @@ def test_find_by_id(find_by_id_data):
                     "name": "Sword of Protection report",
                     "report_id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
                 },
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
         {
@@ -306,7 +309,8 @@ def test_find_by_id(find_by_id_data):
                     "status": 404,
                     "detail": "No reports found with the specified parameters",
                 },
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
     ]
@@ -477,7 +481,8 @@ def test_find(find_data):
                     "name": "Sword of Protection report",
                     "report_id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
                 },
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
         {
@@ -670,7 +675,8 @@ def test_create(create_data, caplog):
                     },
                     "report_id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
                 },
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
         {
@@ -708,9 +714,7 @@ def test_update(update_data):
     params=[
         {
             "args": ["report", "delete", "cd987859-06fe-4b1a-9e96-47d4f36bf819"],
-            "return": json.dumps(
-                {"message": "Successfully deleted 1 row"}
-            ),
+            "return": json.dumps({"message": "Successfully deleted 1 row"}),
         },
         {
             "args": ["report", "delete", "cd987859-06fe-4b1a-9e96-47d4f36bf819"],

--- a/tests/unit/report/test_report_command.py
+++ b/tests/unit/report/test_report_command.py
@@ -714,7 +714,9 @@ def test_update(update_data):
     params=[
         {
             "args": ["report", "delete", "cd987859-06fe-4b1a-9e96-47d4f36bf819"],
-            "return": json.dumps({"message": "Successfully deleted 1 row"}),
+            "return": json.dumps(
+                {"message": "Successfully deleted 1 row"}, indent=4, sort_keys=True
+            ),
         },
         {
             "args": ["report", "delete", "cd987859-06fe-4b1a-9e96-47d4f36bf819"],
@@ -723,7 +725,9 @@ def test_update(update_data):
                     "title": "No report found",
                     "status": 404,
                     "detail": "No report found with the specified ID",
-                }
+                },
+                indent=4,
+                sort_keys=True
             ),
         },
     ]

--- a/tests/unit/rest/test_pipelines.py
+++ b/tests/unit/rest/test_pipelines.py
@@ -1,4 +1,4 @@
-import pprint
+import json
 
 import mockito
 import pytest
@@ -15,24 +15,26 @@ def unstub():
     params=[
         {
             "id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 {
                     "created_at": "2020-09-16T18:48:06.371563",
                     "created_by": "adora@example.com",
                     "description": "This pipeline will save Etheria",
                     "name": "Sword of Protection Pipeline",
                     "pipeline_id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
-                }
+                },
+                indent=4, sort_keys=True
             ),
         },
         {
             "id": "3d1bfbab-d9ec-46c7-aa8e-9c1d1808f2b8",
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 {
                     "title": "No pipeline found",
                     "status": 404,
                     "detail": "No pipeline found with the specified ID",
-                }
+                },
+                indent=4, sort_keys=True
             ),
         },
     ]
@@ -66,7 +68,7 @@ def test_find_by_id(find_by_id_data):
                 ("limit", ""),
                 ("offset", ""),
             ],
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 [
                     {
                         "created_at": "2020-09-16T18:48:08.371563",
@@ -75,7 +77,8 @@ def test_find_by_id(find_by_id_data):
                         "name": "Queen of Bright Moon Pipeline",
                         "pipeline_id": "bd132568-06fe-4b1a-9e96-47d4f36bf819",
                     }
-                ]
+                ],
+                indent=4, sort_keys=True
             ),
         },
         {
@@ -90,12 +93,13 @@ def test_find_by_id(find_by_id_data):
                 ("limit", ""),
                 ("offset", ""),
             ],
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 {
                     "title": "No pipelines found",
                     "status": 404,
                     "detail": "No pipelines found with the specified parameters",
-                }
+                },
+                indent=4, sort_keys=True
             ),
         },
     ]
@@ -133,14 +137,15 @@ def test_find(find_data):
                 ("description", "This pipeline rules the known universe"),
                 ("created_by", "hordeprime@example.com"),
             ],
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 {
                     "created_at": "2020-09-16T18:48:08.371563",
                     "created_by": "hordeprime@example.com",
                     "description": "This pipeline rules the known universe",
                     "name": "Horde Emperor Pipeline",
                     "pipeline_id": "bd132568-06fe-4b1a-9e96-47d4f36bf819",
-                }
+                },
+                indent=4, sort_keys=True
             ),
         },
         {
@@ -149,12 +154,13 @@ def test_find(find_data):
                 ("description", "This pipeline rules the known universe"),
                 ("created_by", "hordeprime@example.com"),
             ],
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 {
                     "title": "Server error",
                     "status": 500,
                     "detail": "Error while attempting to insert new pipeline",
-                }
+                },
+                indent=4, sort_keys=True
             ),
         },
     ]
@@ -189,25 +195,27 @@ def test_create(create_data):
                     "This pipeline is trying to learn to process anger better",
                 ),
             ],
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 {
                     "created_at": "2020-09-16T18:48:08.371563",
                     "created_by": "catra@example.com",
                     "description": "This pipeline is trying to learn to process anger better",
                     "name": "Catra Pipeline",
                     "pipeline_id": "bd132568-06fe-4b1a-9e96-47d4f36bf819",
-                }
+                },
+                indent=4, sort_keys=True
             ),
         },
         {
             "id": "98536487-06fe-4b1a-9e96-47d4f36bf819",
             "params": [("name", "Angella Pipeline"), ("description", "")],
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 {
                     "title": "Server error",
                     "status": 500,
                     "detail": "Error while attempting to update new pipeline",
-                }
+                },
+                indent=4, sort_keys=True
             ),
         },
     ]
@@ -235,18 +243,20 @@ def test_update(update_data):
     params=[
         {
             "id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
-            "return": pprint.PrettyPrinter().pformat(
-                {"message": "Successfully deleted 1 row"}
+            "return": json.dumps(
+                {"message": "Successfully deleted 1 row"},
+                indent=4, sort_keys=True
             ),
         },
         {
             "id": "3d1bfbab-d9ec-46c7-aa8e-9c1d1808f2b8",
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 {
                     "title": "No pipeline found",
                     "status": 404,
                     "detail": "No pipeline found with the specified ID",
-                }
+                },
+                indent=4, sort_keys=True
             ),
         },
     ]
@@ -271,25 +281,27 @@ def test_delete(delete_data):
         {
             "id": "047e27ad-2890-4372-b2cb-dfec57347eb9",
             "email": "bow@example.com",
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 {
                     "subscription_id": "361b3b95-4a6e-40d9-bd98-f92b2959864e",
                     "entity_type": "pipeline",
                     "entity_id": "047e27ad-2890-4372-b2cb-dfec57347eb9",
                     "email": "bow@example.com",
                     "created_at": "2020-09-23T19:41:46.839880",
-                }
+                },
+                indent=4, sort_keys=True
             ),
         },
         {
             "id": "98536487-06fe-4b1a-9e96-47d4f36bf819",
             "email": "huntara@example.com",
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 {
                     "title": "No pipeline found",
                     "status": 404,
                     "detail": "No pipeline found with the specified ID",
-                }
+                },
+                indent=4, sort_keys=True
             ),
         },
     ]
@@ -317,19 +329,21 @@ def test_subscribe(subscribe_data):
         {
             "id": "047e27ad-2890-4372-b2cb-dfec57347eb9",
             "email": "mermista@example.com",
-            "return": pprint.PrettyPrinter().pformat(
-                {"message": "Successfully deleted 1 row(s)"}
+            "return": json.dumps(
+                {"message": "Successfully deleted 1 row(s)"},
+                indent=4, sort_keys=True
             ),
         },
         {
             "id": "98536487-06fe-4b1a-9e96-47d4f36bf819",
             "email": "castaspella@example.com",
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 {
                     "title": "No subscription found",
                     "status": 404,
                     "detail": "No subscription found for the specified parameters",
-                }
+                },
+                indent=4, sort_keys=True
             ),
         },
     ]

--- a/tests/unit/rest/test_pipelines.py
+++ b/tests/unit/rest/test_pipelines.py
@@ -23,7 +23,8 @@ def unstub():
                     "name": "Sword of Protection Pipeline",
                     "pipeline_id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
                 },
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
         {
@@ -34,7 +35,8 @@ def unstub():
                     "status": 404,
                     "detail": "No pipeline found with the specified ID",
                 },
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
     ]
@@ -78,7 +80,8 @@ def test_find_by_id(find_by_id_data):
                         "pipeline_id": "bd132568-06fe-4b1a-9e96-47d4f36bf819",
                     }
                 ],
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
         {
@@ -99,7 +102,8 @@ def test_find_by_id(find_by_id_data):
                     "status": 404,
                     "detail": "No pipelines found with the specified parameters",
                 },
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
     ]
@@ -145,7 +149,8 @@ def test_find(find_data):
                     "name": "Horde Emperor Pipeline",
                     "pipeline_id": "bd132568-06fe-4b1a-9e96-47d4f36bf819",
                 },
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
         {
@@ -160,7 +165,8 @@ def test_find(find_data):
                     "status": 500,
                     "detail": "Error while attempting to insert new pipeline",
                 },
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
     ]
@@ -203,7 +209,8 @@ def test_create(create_data):
                     "name": "Catra Pipeline",
                     "pipeline_id": "bd132568-06fe-4b1a-9e96-47d4f36bf819",
                 },
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
         {
@@ -215,7 +222,8 @@ def test_create(create_data):
                     "status": 500,
                     "detail": "Error while attempting to update new pipeline",
                 },
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
     ]
@@ -244,8 +252,7 @@ def test_update(update_data):
         {
             "id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
             "return": json.dumps(
-                {"message": "Successfully deleted 1 row"},
-                indent=4, sort_keys=True
+                {"message": "Successfully deleted 1 row"}, indent=4, sort_keys=True
             ),
         },
         {
@@ -256,7 +263,8 @@ def test_update(update_data):
                     "status": 404,
                     "detail": "No pipeline found with the specified ID",
                 },
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
     ]
@@ -289,7 +297,8 @@ def test_delete(delete_data):
                     "email": "bow@example.com",
                     "created_at": "2020-09-23T19:41:46.839880",
                 },
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
         {
@@ -301,7 +310,8 @@ def test_delete(delete_data):
                     "status": 404,
                     "detail": "No pipeline found with the specified ID",
                 },
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
     ]
@@ -330,8 +340,7 @@ def test_subscribe(subscribe_data):
             "id": "047e27ad-2890-4372-b2cb-dfec57347eb9",
             "email": "mermista@example.com",
             "return": json.dumps(
-                {"message": "Successfully deleted 1 row(s)"},
-                indent=4, sort_keys=True
+                {"message": "Successfully deleted 1 row(s)"}, indent=4, sort_keys=True
             ),
         },
         {
@@ -343,7 +352,8 @@ def test_subscribe(subscribe_data):
                     "status": 404,
                     "detail": "No subscription found for the specified parameters",
                 },
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
     ]

--- a/tests/unit/rest/test_reports.py
+++ b/tests/unit/rest/test_reports.py
@@ -78,7 +78,8 @@ def unstub():
                     "name": "Sword of Protection report",
                     "report_id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
                 },
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
         {
@@ -89,7 +90,8 @@ def unstub():
                     "status": 404,
                     "detail": "No report found with the specified ID",
                 },
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
     ]
@@ -193,7 +195,8 @@ def test_find_by_id(find_by_id_data):
                         "report_id": "bd132568-06fe-4b1a-9e96-47d4f36bf819",
                     }
                 ],
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
         {
@@ -216,7 +219,8 @@ def test_find_by_id(find_by_id_data):
                     "status": 404,
                     "detail": "No reports found with the specified parameters",
                 },
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
     ]
@@ -377,7 +381,8 @@ def test_find(find_data):
                     "name": "Horde Emperor report",
                     "report_id": "bd132568-06fe-4b1a-9e96-47d4f36bf819",
                 },
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
         {
@@ -450,7 +455,8 @@ def test_find(find_data):
                     "status": 500,
                     "detail": "Error while attempting to insert new report",
                 },
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
     ]
@@ -608,7 +614,8 @@ def test_create(create_data):
                     "name": "Catra report",
                     "report_id": "bd132568-06fe-4b1a-9e96-47d4f36bf819",
                 },
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
         {
@@ -681,7 +688,8 @@ def test_create(create_data):
                     "status": 500,
                     "detail": "Error while attempting to update new report",
                 },
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
     ]
@@ -712,8 +720,7 @@ def test_update(update_data):
         {
             "id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
             "return": json.dumps(
-                {"message": "Successfully deleted 1 row"},
-                indent=4, sort_keys=True
+                {"message": "Successfully deleted 1 row"}, indent=4, sort_keys=True
             ),
         },
         {
@@ -724,7 +731,8 @@ def test_update(update_data):
                     "status": 404,
                     "detail": "No report found with the specified ID",
                 },
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
     ]

--- a/tests/unit/rest/test_reports.py
+++ b/tests/unit/rest/test_reports.py
@@ -1,4 +1,4 @@
-import pprint
+import json
 
 import mockito
 import pytest
@@ -15,7 +15,7 @@ def unstub():
     params=[
         {
             "id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 {
                     "created_at": "2020-09-16T18:48:06.371563",
                     "created_by": "adora@example.com",
@@ -77,17 +77,19 @@ def unstub():
                     "description": "This report will save Etheria",
                     "name": "Sword of Protection report",
                     "report_id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
-                }
+                },
+                indent=4, sort_keys=True
             ),
         },
         {
             "id": "3d1bfbab-d9ec-46c7-aa8e-9c1d1808f2b8",
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 {
                     "title": "No report found",
                     "status": 404,
                     "detail": "No report found with the specified ID",
-                }
+                },
+                indent=4, sort_keys=True
             ),
         },
     ]
@@ -123,7 +125,7 @@ def test_find_by_id(find_by_id_data):
                 ("limit", ""),
                 ("offset", ""),
             ],
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 [
                     {
                         "created_at": "2020-09-16T18:48:08.371563",
@@ -190,7 +192,8 @@ def test_find_by_id(find_by_id_data):
                         "name": "Queen of Bright Moon report",
                         "report_id": "bd132568-06fe-4b1a-9e96-47d4f36bf819",
                     }
-                ]
+                ],
+                indent=4, sort_keys=True
             ),
         },
         {
@@ -207,12 +210,13 @@ def test_find_by_id(find_by_id_data):
                 ("limit", ""),
                 ("offset", ""),
             ],
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 {
                     "title": "No reports found",
                     "status": 404,
                     "detail": "No reports found with the specified parameters",
-                }
+                },
+                indent=4, sort_keys=True
             ),
         },
     ]
@@ -310,7 +314,7 @@ def test_find(find_data):
                 ("config", {"cpu": 2}),
                 ("created_by", "hordeprime@example.com"),
             ],
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 {
                     "created_at": "2020-09-16T18:48:08.371563",
                     "created_by": "hordeprime@example.com",
@@ -372,7 +376,8 @@ def test_find(find_data):
                     "description": "This report rules the known universe",
                     "name": "Horde Emperor report",
                     "report_id": "bd132568-06fe-4b1a-9e96-47d4f36bf819",
-                }
+                },
+                indent=4, sort_keys=True
             ),
         },
         {
@@ -439,12 +444,13 @@ def test_find(find_data):
                 ("config", {"cpu": 2}),
                 ("created_by", "hordeprime@example.com"),
             ],
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 {
                     "title": "Server error",
                     "status": 500,
                     "detail": "Error while attempting to insert new report",
-                }
+                },
+                indent=4, sort_keys=True
             ),
         },
     ]
@@ -539,7 +545,7 @@ def test_create(create_data):
                 ),
                 ("config", {"cpu": 2}),
             ],
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 {
                     "created_at": "2020-09-16T18:48:08.371563",
                     "created_by": "catra@example.com",
@@ -601,7 +607,8 @@ def test_create(create_data):
                     "description": "This report is trying to learn to process anger better",
                     "name": "Catra report",
                     "report_id": "bd132568-06fe-4b1a-9e96-47d4f36bf819",
-                }
+                },
+                indent=4, sort_keys=True
             ),
         },
         {
@@ -668,12 +675,13 @@ def test_create(create_data):
                 ),
                 ("config", {"cpu": 2}),
             ],
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 {
                     "title": "Server error",
                     "status": 500,
                     "detail": "Error while attempting to update new report",
-                }
+                },
+                indent=4, sort_keys=True
             ),
         },
     ]
@@ -703,18 +711,20 @@ def test_update(update_data):
     params=[
         {
             "id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
-            "return": pprint.PrettyPrinter().pformat(
-                {"message": "Successfully deleted 1 row"}
+            "return": json.dumps(
+                {"message": "Successfully deleted 1 row"},
+                indent=4, sort_keys=True
             ),
         },
         {
             "id": "3d1bfbab-d9ec-46c7-aa8e-9c1d1808f2b8",
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 {
                     "title": "No report found",
                     "status": 404,
                     "detail": "No report found with the specified ID",
-                }
+                },
+                indent=4, sort_keys=True
             ),
         },
     ]

--- a/tests/unit/rest/test_request_handler.py
+++ b/tests/unit/rest/test_request_handler.py
@@ -1,6 +1,4 @@
 import json
-import pprint
-import urllib
 
 import requests
 
@@ -21,20 +19,21 @@ def unstub():
         {
             "entity": "pipelines",
             "id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 {
                     "created_at": "2020-09-16T18:48:06.371563",
                     "created_by": "adora@example.com",
                     "description": "This pipeline will save Etheria",
                     "name": "Sword of Protection Pipeline",
                     "pipeline_id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
-                }
+                },
+                indent=4, sort_keys=True
             ),
         },
         {
             "entity": "templates",
             "id": "3d1bfbab-d9ec-46c7-aa8e-9c1d1808f2b8",
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 {
                     "created_at": "2020-09-02T13:41:44.217522",
                     "created_by": "catra@example.com",
@@ -44,7 +43,8 @@ def unstub():
                     "name": "Catra template",
                     "pipeline_id": "3d1bfbab-d9ec-46c7-aa8e-9c1d1808f2b8",
                     "template_id": "58723b05-6060-4444-9f1b-394aff691cce",
-                }
+                },
+                indent=4, sort_keys=True
             ),
         },
     ]
@@ -78,7 +78,7 @@ def test_find_by_id(find_by_id_data):
         {
             "entity": "pipelines",
             "params": [("name", "Queen of Bright Moon Pipeline")],
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 [
                     {
                         "created_at": "2020-09-16T18:48:08.371563",
@@ -87,18 +87,20 @@ def test_find_by_id(find_by_id_data):
                         "name": "Queen of Bright Moon Pipeline",
                         "pipeline_id": "bd132568-06fe-4b1a-9e96-47d4f36bf819",
                     }
-                ]
+                ],
+                indent=4, sort_keys=True
             ),
         },
         {
             "entity": "pipelines",
             "params": [("id", "3d1bfbab-d9ec-46c7-aa8e-9c1d1808f2b8"), ("name", "")],
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 {
                     "title": "No pipelines found",
                     "status": 404,
                     "detail": "No pipelines found with the specified parameters",
-                }
+                },
+                indent=4, sort_keys=True
             ),
         },
     ]
@@ -132,14 +134,15 @@ def test_find(find_data):
                 ("description", "This pipeline rules the known universe"),
                 ("created_by", "hordeprime@example.com"),
             ],
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 {
                     "created_at": "2020-09-16T18:48:08.371563",
                     "created_by": "hordeprime@example.com",
                     "description": "This pipeline rules the known universe",
                     "name": "Horde Emperor Pipeline",
                     "pipeline_id": "bd132568-06fe-4b1a-9e96-47d4f36bf819",
-                }
+                },
+                indent=4, sort_keys=True
             ),
         },
         {
@@ -177,7 +180,7 @@ def test_create(create_data):
             "params": [
                 ("description", "This template is working on her abandonment issues")
             ],
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 {
                     "created_at": "2020-09-02T13:41:44.217522",
                     "created_by": "catra@example.com",
@@ -187,19 +190,21 @@ def test_create(create_data):
                     "name": "Catra template",
                     "pipeline_id": "3d1bfbab-d9ec-46c7-aa8e-9c1d1808f2b8",
                     "template_id": "58723b05-6060-4444-9f1b-394aff691cce",
-                }
+                },
+                indent=4, sort_keys=True
             ),
         },
         {
             "entity": "pipelines",
             "id": "3d1bfbab-d9ec-46c7-aa8e-9c1d1808f2b8",
             "params": [],
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 {
                     "title": "Server error",
                     "status": 500,
                     "detail": "Error while attempting to update pipeline",
-                }
+                },
+                indent=4, sort_keys=True
             ),
         },
     ]
@@ -235,19 +240,21 @@ def test_update(update_data):
         {
             "entity": "pipelines",
             "id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
-            "return": pprint.PrettyPrinter().pformat(
-                {"message": "Successfully deleted 1 row"}
+            "return": json.dumps(
+                {"message": "Successfully deleted 1 row"},
+                indent=4, sort_keys=True
             ),
         },
         {
             "entity": "templates",
             "id": "3d1bfbab-d9ec-46c7-aa8e-9c1d1808f2b8",
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 {
                     "title": "No template found",
                     "status": 404,
                     "detail": "No template found for the specified id",
-                }
+                },
+                indent=4, sort_keys=True
             ),
         },
     ]
@@ -280,26 +287,28 @@ def test_delete(delete_data):
             "entity": "pipelines",
             "id": "047e27ad-2890-4372-b2cb-dfec57347eb9",
             "email": "bow@example.com",
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 {
                     "subscription_id": "361b3b95-4a6e-40d9-bd98-f92b2959864e",
                     "entity_type": "pipeline",
                     "entity_id": "047e27ad-2890-4372-b2cb-dfec57347eb9",
                     "email": "bow@example.com",
                     "created_at": "2020-09-23T19:41:46.839880",
-                }
+                },
+                indent=4, sort_keys=True
             ),
         },
         {
             "entity": "pipelines",
             "id": "3d1bfbab-d9ec-46c7-aa8e-9c1d1808f2b8",
             "email": "huntara@example.com",
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 {
                     "title": "No pipeline found",
                     "status": 404,
                     "detail": "No pipeline found with the specified ID",
-                }
+                },
+                indent=4, sort_keys=True
             ),
         },
     ]
@@ -336,20 +345,22 @@ def test_subscribe(subscribe_data):
             "entity": "pipelines",
             "id": "047e27ad-2890-4372-b2cb-dfec57347eb9",
             "email": "mermista@example.com",
-            "return": pprint.PrettyPrinter().pformat(
-                {"message": "Successfully deleted 1 row(s)"}
+            "return": json.dumps(
+                {"message": "Successfully deleted 1 row(s)"},
+                indent=4, sort_keys=True
             ),
         },
         {
             "entity": "pipelines",
             "id": "3d1bfbab-d9ec-46c7-aa8e-9c1d1808f2b8",
             "email": "castaspella@example.com",
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 {
                     "title": "No subscription found",
                     "status": 404,
                     "detail": "No subscription found for the specified parameters",
-                }
+                },
+                indent=4, sort_keys=True
             ),
         },
     ]
@@ -389,7 +400,7 @@ def test_unsubscribe(unsubscribe_data):
                 ("test_input", {"species": "Alicorn"}),
                 ("created_by", "swiftwind@example.com"),
             ],
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 {
                     "run_id": "69717609-0e95-4c9c-965c-1ea40a2cf44f",
                     "test_id": "c97c25e5-4adf-4db7-8f64-19af34d84ef8",
@@ -401,7 +412,8 @@ def test_unsubscribe(unsubscribe_data):
                     "created_at": "2020-09-24T15:50:49.641333",
                     "created_by": "swiftwind@example.com",
                     "finished_at": None,
-                }
+                },
+                indent=4, sort_keys=True
             ),
         },
         {
@@ -411,12 +423,13 @@ def test_unsubscribe(unsubscribe_data):
                 ("test_input", {"occupation": "Princess"}),
                 ("created_by", "perfuma@example.com"),
             ],
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 {
                     "title": "Server error",
                     "status": 500,
                     "detail": "Error while attempting to query the database: NotFound",
-                }
+                },
+                indent=4, sort_keys=True
             ),
         },
     ]
@@ -450,7 +463,7 @@ def test_run(run_data):
             "entity": "tests",
             "id": "5fad47be-0d23-4679-8d8c-deff717d5419",
             "params": [("name", "Entrapta Test Run")],
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 [
                     {
                         "run_id": "8ff51b0a-cdbf-409f-9e8b-888524ae9c1a",
@@ -467,19 +480,21 @@ def test_run(run_data):
                         "finished_at": "2020-09-10T14:03:27.658",
                         "results": {"ShipName": "Darla"},
                     }
-                ]
+                ],
+                indent=4, sort_keys=True
             ),
         },
         {
             "entity": "templates",
             "id": "3d1bfbab-d9ec-46c7-aa8e-9c1d1808f2b8",
             "params": [("id", ""), ("name", "Mara's Test Run")],
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 {
                     "title": "No run found",
                     "status": 404,
                     "detail": "No runs found with the specified parameters",
-                }
+                },
+                indent=4, sort_keys=True
             ),
         },
     ]
@@ -521,14 +536,15 @@ def test_find_runs(find_runs_data):
                 ("result_key", "out_horde_tanks"),
                 ("created_by", "rogelio@example.com"),
             ],
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 {
                     "template_id": "5fad47be-0d23-4679-8d8c-deff717d5419",
                     "result_id": "8ff51b0a-cdbf-409f-9e8b-888524ae9c1a",
                     "result_key": "out_horde_tanks",
                     "created_at": "2020-09-24T19:07:59.311462",
                     "created_by": "rogelio@example.com",
-                }
+                },
+                indent=4, sort_keys=True
             ),
         },
         {
@@ -540,12 +556,13 @@ def test_find_runs(find_runs_data):
                 ("result_key", "out_force_captain"),
                 ("created_by", "kyle@example.com"),
             ],
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 {
                     "title": "Server error",
                     "status": 500,
                     "detail": "Error while attempting to insert new template result mapping",
-                }
+                },
+                indent=4, sort_keys=True
             ),
         },
     ]
@@ -589,14 +606,15 @@ def test_create_map(create_map_data):
             "entity1_id": "5fad47be-0d23-4679-8d8c-deff717d5419",
             "entity2": "results",
             "entity2_id": "8ff51b0a-cdbf-409f-9e8b-888524ae9c1a",
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 {
                     "template_id": "5fad47be-0d23-4679-8d8c-deff717d5419",
                     "result_id": "8ff51b0a-cdbf-409f-9e8b-888524ae9c1a",
                     "result_key": "out_horde_tanks",
                     "created_at": "2020-09-24T19:07:59.311462",
                     "created_by": "rogelio@example.com",
-                }
+                },
+                indent=4, sort_keys=True
             ),
         },
         {
@@ -604,12 +622,13 @@ def test_create_map(create_map_data):
             "entity1_id": "5fad47be-0d23-4679-8d8c-deff717d5419",
             "entity2": "results",
             "entity2_id": "8ff51b0a-cdbf-409f-9e8b-888524ae9c1a",
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 {
                     "title": "No template_result mapping found",
                     "status": 404,
                     "detail": "No template_result mapping found with the specified ID",
-                }
+                },
+                indent=4, sort_keys=True
             ),
         },
     ]
@@ -650,8 +669,9 @@ def test_find_map_by_ids(find_map_by_ids_data):
             "entity1_id": "5fad47be-0d23-4679-8d8c-deff717d5419",
             "entity2": "results",
             "entity2_id": "8ff51b0a-cdbf-409f-9e8b-888524ae9c1a",
-            "return": pprint.PrettyPrinter().pformat(
-                {"message": "Successfully deleted 1 row"}
+            "return": json.dumps(
+                {"message": "Successfully deleted 1 row"},
+                indent=4, sort_keys=True
             ),
         },
         {
@@ -659,12 +679,13 @@ def test_find_map_by_ids(find_map_by_ids_data):
             "entity1_id": "5fad47be-0d23-4679-8d8c-deff717d5419",
             "entity2": "results",
             "entity2_id": "8ff51b0a-cdbf-409f-9e8b-888524ae9c1a",
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 {
                     "title": "No template_result mapping found",
                     "status": 404,
                     "detail": "No template_result mapping found with the specified ID",
-                }
+                },
+                indent=4, sort_keys=True
             ),
         },
     ]
@@ -714,14 +735,15 @@ def test_delete_map_by_ids(delete_map_by_ids_data):
                 ("limit", ""),
                 ("offset", ""),
             ],
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 {
                     "template_id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
                     "result_id": "3d1bfbab-d9ec-46c7-aa8e-9c1d1808f2b8",
                     "result_key": "out_horde_tanks",
                     "created_at": "2020-09-24T19:07:59.311462",
                     "created_by": "rogelio@example.com",
-                }
+                },
+                indent=4, sort_keys=True
             ),
         },
         {
@@ -738,12 +760,13 @@ def test_delete_map_by_ids(delete_map_by_ids_data):
                 ("limit", ""),
                 ("offset", ""),
             ],
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 {
                     "title": "No template_result mapping found",
                     "status": 404,
                     "detail": "No template_result mapping found with the specified parameters",
-                }
+                },
+                indent=4, sort_keys=True
             ),
         },
     ]
@@ -796,12 +819,17 @@ def test_find_maps(find_maps_data):
             "exception": requests.TooManyRedirects,
             "return": "Too many redirects. Enable verbose logging (-v) for more info",
         },
-        {"status_code": 400, "text": "", "return": "{'Body': '', 'Status': 400}"},
+        {
+            "status_code": 400,
+            "text": "",
+            "return": json.dumps({"Body": "", "Status": 400}, indent=4, sort_keys=True)
+        },
         {
             "status_code": 200,
             "text": json.dumps({"test_id": "123456789", "name": "test_name"}),
-            "return": pprint.PrettyPrinter().pformat(
-                {"name": "test_name", "test_id": "123456789"}
+            "return": json.dumps(
+                {"name": "test_name", "test_id": "123456789"},
+                indent=4, sort_keys=True
             ),
         },
     ]

--- a/tests/unit/rest/test_request_handler.py
+++ b/tests/unit/rest/test_request_handler.py
@@ -27,7 +27,8 @@ def unstub():
                     "name": "Sword of Protection Pipeline",
                     "pipeline_id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
                 },
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
         {
@@ -44,7 +45,8 @@ def unstub():
                     "pipeline_id": "3d1bfbab-d9ec-46c7-aa8e-9c1d1808f2b8",
                     "template_id": "58723b05-6060-4444-9f1b-394aff691cce",
                 },
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
     ]
@@ -88,7 +90,8 @@ def test_find_by_id(find_by_id_data):
                         "pipeline_id": "bd132568-06fe-4b1a-9e96-47d4f36bf819",
                     }
                 ],
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
         {
@@ -100,7 +103,8 @@ def test_find_by_id(find_by_id_data):
                     "status": 404,
                     "detail": "No pipelines found with the specified parameters",
                 },
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
     ]
@@ -142,7 +146,8 @@ def test_find(find_data):
                     "name": "Horde Emperor Pipeline",
                     "pipeline_id": "bd132568-06fe-4b1a-9e96-47d4f36bf819",
                 },
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
         {
@@ -191,7 +196,8 @@ def test_create(create_data):
                     "pipeline_id": "3d1bfbab-d9ec-46c7-aa8e-9c1d1808f2b8",
                     "template_id": "58723b05-6060-4444-9f1b-394aff691cce",
                 },
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
         {
@@ -204,7 +210,8 @@ def test_create(create_data):
                     "status": 500,
                     "detail": "Error while attempting to update pipeline",
                 },
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
     ]
@@ -241,8 +248,7 @@ def test_update(update_data):
             "entity": "pipelines",
             "id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
             "return": json.dumps(
-                {"message": "Successfully deleted 1 row"},
-                indent=4, sort_keys=True
+                {"message": "Successfully deleted 1 row"}, indent=4, sort_keys=True
             ),
         },
         {
@@ -254,7 +260,8 @@ def test_update(update_data):
                     "status": 404,
                     "detail": "No template found for the specified id",
                 },
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
     ]
@@ -295,7 +302,8 @@ def test_delete(delete_data):
                     "email": "bow@example.com",
                     "created_at": "2020-09-23T19:41:46.839880",
                 },
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
         {
@@ -308,7 +316,8 @@ def test_delete(delete_data):
                     "status": 404,
                     "detail": "No pipeline found with the specified ID",
                 },
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
     ]
@@ -346,8 +355,7 @@ def test_subscribe(subscribe_data):
             "id": "047e27ad-2890-4372-b2cb-dfec57347eb9",
             "email": "mermista@example.com",
             "return": json.dumps(
-                {"message": "Successfully deleted 1 row(s)"},
-                indent=4, sort_keys=True
+                {"message": "Successfully deleted 1 row(s)"}, indent=4, sort_keys=True
             ),
         },
         {
@@ -360,7 +368,8 @@ def test_subscribe(subscribe_data):
                     "status": 404,
                     "detail": "No subscription found for the specified parameters",
                 },
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
     ]
@@ -413,7 +422,8 @@ def test_unsubscribe(unsubscribe_data):
                     "created_by": "swiftwind@example.com",
                     "finished_at": None,
                 },
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
         {
@@ -429,7 +439,8 @@ def test_unsubscribe(unsubscribe_data):
                     "status": 500,
                     "detail": "Error while attempting to query the database: NotFound",
                 },
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
     ]
@@ -481,7 +492,8 @@ def test_run(run_data):
                         "results": {"ShipName": "Darla"},
                     }
                 ],
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
         {
@@ -494,7 +506,8 @@ def test_run(run_data):
                     "status": 404,
                     "detail": "No runs found with the specified parameters",
                 },
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
     ]
@@ -544,7 +557,8 @@ def test_find_runs(find_runs_data):
                     "created_at": "2020-09-24T19:07:59.311462",
                     "created_by": "rogelio@example.com",
                 },
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
         {
@@ -562,7 +576,8 @@ def test_find_runs(find_runs_data):
                     "status": 500,
                     "detail": "Error while attempting to insert new template result mapping",
                 },
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
     ]
@@ -614,7 +629,8 @@ def test_create_map(create_map_data):
                     "created_at": "2020-09-24T19:07:59.311462",
                     "created_by": "rogelio@example.com",
                 },
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
         {
@@ -628,7 +644,8 @@ def test_create_map(create_map_data):
                     "status": 404,
                     "detail": "No template_result mapping found with the specified ID",
                 },
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
     ]
@@ -670,8 +687,7 @@ def test_find_map_by_ids(find_map_by_ids_data):
             "entity2": "results",
             "entity2_id": "8ff51b0a-cdbf-409f-9e8b-888524ae9c1a",
             "return": json.dumps(
-                {"message": "Successfully deleted 1 row"},
-                indent=4, sort_keys=True
+                {"message": "Successfully deleted 1 row"}, indent=4, sort_keys=True
             ),
         },
         {
@@ -685,7 +701,8 @@ def test_find_map_by_ids(find_map_by_ids_data):
                     "status": 404,
                     "detail": "No template_result mapping found with the specified ID",
                 },
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
     ]
@@ -743,7 +760,8 @@ def test_delete_map_by_ids(delete_map_by_ids_data):
                     "created_at": "2020-09-24T19:07:59.311462",
                     "created_by": "rogelio@example.com",
                 },
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
         {
@@ -766,7 +784,8 @@ def test_delete_map_by_ids(delete_map_by_ids_data):
                     "status": 404,
                     "detail": "No template_result mapping found with the specified parameters",
                 },
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
     ]
@@ -822,14 +841,13 @@ def test_find_maps(find_maps_data):
         {
             "status_code": 400,
             "text": "",
-            "return": json.dumps({"Body": "", "Status": 400}, indent=4, sort_keys=True)
+            "return": json.dumps({"Body": "", "Status": 400}, indent=4, sort_keys=True),
         },
         {
             "status_code": 200,
             "text": json.dumps({"test_id": "123456789", "name": "test_name"}),
             "return": json.dumps(
-                {"name": "test_name", "test_id": "123456789"},
-                indent=4, sort_keys=True
+                {"name": "test_name", "test_id": "123456789"}, indent=4, sort_keys=True
             ),
         },
     ]

--- a/tests/unit/rest/test_results.py
+++ b/tests/unit/rest/test_results.py
@@ -24,7 +24,8 @@ def unstub():
                     "result_type": "file",
                     "result_id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
                 },
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
         {
@@ -35,7 +36,8 @@ def unstub():
                     "status": 404,
                     "detail": "No result found with the specified ID",
                 },
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
     ]
@@ -81,7 +83,8 @@ def test_find_by_id(find_by_id_data):
                         "result_id": "bd132568-06fe-4b1a-9e96-47d4f36bf819",
                     }
                 ],
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
         {
@@ -103,7 +106,8 @@ def test_find_by_id(find_by_id_data):
                     "status": 404,
                     "detail": "No results found with the specified parameters",
                 },
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
     ]
@@ -152,7 +156,8 @@ def test_find(find_data):
                     "name": "Horde Emperor result",
                     "result_id": "bd132568-06fe-4b1a-9e96-47d4f36bf819",
                 },
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
         {
@@ -168,7 +173,8 @@ def test_find(find_data):
                     "status": 500,
                     "detail": "Error while attempting to insert new result",
                 },
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
     ]
@@ -213,7 +219,8 @@ def test_create(create_data):
                     "result_type": "numeric",
                     "result_id": "bd132568-06fe-4b1a-9e96-47d4f36bf819",
                 },
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
         {
@@ -225,7 +232,8 @@ def test_create(create_data):
                     "status": 500,
                     "detail": "Error while attempting to update new result",
                 },
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
     ]
@@ -254,8 +262,7 @@ def test_update(update_data):
         {
             "id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
             "return": json.dumps(
-                {"message": "Successfully deleted 1 row"},
-                indent=4, sort_keys=True
+                {"message": "Successfully deleted 1 row"}, indent=4, sort_keys=True
             ),
         },
         {
@@ -266,7 +273,8 @@ def test_update(update_data):
                     "status": 404,
                     "detail": "No result found with the specified ID",
                 },
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
     ]

--- a/tests/unit/rest/test_results.py
+++ b/tests/unit/rest/test_results.py
@@ -1,4 +1,4 @@
-import pprint
+import json
 
 import mockito
 import pytest
@@ -15,7 +15,7 @@ def unstub():
     params=[
         {
             "id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 {
                     "created_at": "2020-09-16T18:48:06.371563",
                     "created_by": "adora@example.com",
@@ -23,17 +23,19 @@ def unstub():
                     "name": "Sword of Protection result",
                     "result_type": "file",
                     "result_id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
-                }
+                },
+                indent=4, sort_keys=True
             ),
         },
         {
             "id": "3d1bfbab-d9ec-46c7-aa8e-9c1d1808f2b8",
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 {
                     "title": "No result found",
                     "status": 404,
                     "detail": "No result found with the specified ID",
-                }
+                },
+                indent=4, sort_keys=True
             ),
         },
     ]
@@ -68,7 +70,7 @@ def test_find_by_id(find_by_id_data):
                 ("limit", ""),
                 ("offset", ""),
             ],
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 [
                     {
                         "created_at": "2020-09-16T18:48:08.371563",
@@ -78,7 +80,8 @@ def test_find_by_id(find_by_id_data):
                         "result_type": "text",
                         "result_id": "bd132568-06fe-4b1a-9e96-47d4f36bf819",
                     }
-                ]
+                ],
+                indent=4, sort_keys=True
             ),
         },
         {
@@ -94,12 +97,13 @@ def test_find_by_id(find_by_id_data):
                 ("limit", ""),
                 ("offset", ""),
             ],
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 {
                     "title": "No results found",
                     "status": 404,
                     "detail": "No results found with the specified parameters",
-                }
+                },
+                indent=4, sort_keys=True
             ),
         },
     ]
@@ -139,7 +143,7 @@ def test_find(find_data):
                 ("result_type", "file"),
                 ("created_by", "hordeprime@example.com"),
             ],
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 {
                     "created_at": "2020-09-16T18:48:08.371563",
                     "created_by": "hordeprime@example.com",
@@ -147,7 +151,8 @@ def test_find(find_data):
                     "result_type": "file",
                     "name": "Horde Emperor result",
                     "result_id": "bd132568-06fe-4b1a-9e96-47d4f36bf819",
-                }
+                },
+                indent=4, sort_keys=True
             ),
         },
         {
@@ -157,12 +162,13 @@ def test_find(find_data):
                 ("result_type", "numeric"),
                 ("created_by", "hordeprime@example.com"),
             ],
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 {
                     "title": "Server error",
                     "status": 500,
                     "detail": "Error while attempting to insert new result",
-                }
+                },
+                indent=4, sort_keys=True
             ),
         },
     ]
@@ -198,7 +204,7 @@ def test_create(create_data):
                     "This result is trying to learn to process anger better",
                 ),
             ],
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 {
                     "created_at": "2020-09-16T18:48:08.371563",
                     "created_by": "catra@example.com",
@@ -206,18 +212,20 @@ def test_create(create_data):
                     "name": "Catra result",
                     "result_type": "numeric",
                     "result_id": "bd132568-06fe-4b1a-9e96-47d4f36bf819",
-                }
+                },
+                indent=4, sort_keys=True
             ),
         },
         {
             "id": "98536487-06fe-4b1a-9e96-47d4f36bf819",
             "params": [("name", "Angella result"), ("description", "")],
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 {
                     "title": "Server error",
                     "status": 500,
                     "detail": "Error while attempting to update new result",
-                }
+                },
+                indent=4, sort_keys=True
             ),
         },
     ]
@@ -245,18 +253,20 @@ def test_update(update_data):
     params=[
         {
             "id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
-            "return": pprint.PrettyPrinter().pformat(
-                {"message": "Successfully deleted 1 row"}
+            "return": json.dumps(
+                {"message": "Successfully deleted 1 row"},
+                indent=4, sort_keys=True
             ),
         },
         {
             "id": "3d1bfbab-d9ec-46c7-aa8e-9c1d1808f2b8",
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 {
                     "title": "No result found",
                     "status": 404,
                     "detail": "No result found with the specified ID",
-                }
+                },
+                indent=4, sort_keys=True
             ),
         },
     ]

--- a/tests/unit/rest/test_run_reports.py
+++ b/tests/unit/rest/test_run_reports.py
@@ -1,4 +1,4 @@
-import pprint
+import json
 
 import mockito
 import pytest
@@ -12,7 +12,7 @@ from carrot_cli.rest import request_handler, run_reports
             "report_id": "3d1bfbab-d9ec-46c7-aa8e-9c1d1808f2b8",
             "created_by": "rogelio@example.com",
             "delete_failed": True,
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 {
                     "run_id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
                     "report_id": "3d1bfbab-d9ec-46c7-aa8e-9c1d1808f2b8",
@@ -22,7 +22,8 @@ from carrot_cli.rest import request_handler, run_reports
                     "created_at": "2020-09-24T19:07:59.311462",
                     "created_by": "rogelio@example.com",
                     "finished_at": None,
-                }
+                },
+                indent=4, sort_keys=True
             ),
         },
         {
@@ -30,12 +31,13 @@ from carrot_cli.rest import request_handler, run_reports
             "report_id": "3d1bfbab-d9ec-46c7-aa8e-9c1d1808f2b8",
             "created_by": "rogelio@example.com",
             "delete_failed": False,
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 {
                     "title": "Server error",
                     "status": 500,
                     "detail": "Error while attempting to insert new run report mapping",
-                }
+                },
+                indent=4, sort_keys=True
             ),
         },
     ]
@@ -89,7 +91,7 @@ def test_create_map(create_map_data):
                 ("limit", ""),
                 ("offset", ""),
             ],
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 {
                     "run_id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
                     "report_id": "3d1bfbab-d9ec-46c7-aa8e-9c1d1808f2b8",
@@ -99,7 +101,8 @@ def test_create_map(create_map_data):
                     "created_at": "2020-09-24T19:07:59.311462",
                     "created_by": "rogelio@example.com",
                     "finished_at": "2020-09-24T19:09:59.311462",
-                }
+                },
+                indent=4, sort_keys=True
             ),
         },
         {
@@ -118,12 +121,13 @@ def test_create_map(create_map_data):
                 ("limit", ""),
                 ("offset", ""),
             ],
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 {
                     "title": "No run_report mapping found",
                     "status": 404,
                     "detail": "No run_report mapping found with the specified parameters",
-                }
+                },
+                indent=4, sort_keys=True
             ),
         },
     ]
@@ -162,7 +166,7 @@ def test_find_maps(find_maps_data):
         {
             "run_id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
             "report_id": "3d1bfbab-d9ec-46c7-aa8e-9c1d1808f2b8",
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 {
                     "run_id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
                     "report_id": "3d1bfbab-d9ec-46c7-aa8e-9c1d1808f2b8",
@@ -172,18 +176,20 @@ def test_find_maps(find_maps_data):
                     "created_at": "2020-09-24T19:07:59.311462",
                     "created_by": "rogelio@example.com",
                     "finished_at": "2020-09-24T21:07:59.311462",
-                }
+                },
+                indent=4, sort_keys=True
             ),
         },
         {
             "run_id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
             "report_id": "3d1bfbab-d9ec-46c7-aa8e-9c1d1808f2b8",
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 {
                     "title": "No run_report mapping found",
                     "status": 404,
                     "detail": "No run_report mapping found with the specified ID",
-                }
+                },
+                indent=4, sort_keys=True
             ),
         },
     ]
@@ -210,19 +216,21 @@ def test_find_maps_by_id(find_map_by_ids_data):
         {
             "run_id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
             "report_id": "3d1bfbab-d9ec-46c7-aa8e-9c1d1808f2b8",
-            "return": pprint.PrettyPrinter().pformat(
-                {"message": "Successfully deleted 1 row"}
+            "return": json.dumps(
+                {"message": "Successfully deleted 1 row"},
+                indent=4, sort_keys=True
             ),
         },
         {
             "run_id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
             "report_id": "3d1bfbab-d9ec-46c7-aa8e-9c1d1808f2b8",
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 {
                     "title": "No run_report mapping found",
                     "status": 404,
                     "detail": "No run_report mapping found with the specified ID",
-                }
+                },
+                indent=4, sort_keys=True
             ),
         },
     ]

--- a/tests/unit/rest/test_run_reports.py
+++ b/tests/unit/rest/test_run_reports.py
@@ -23,7 +23,8 @@ from carrot_cli.rest import request_handler, run_reports
                     "created_by": "rogelio@example.com",
                     "finished_at": None,
                 },
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
         {
@@ -37,7 +38,8 @@ from carrot_cli.rest import request_handler, run_reports
                     "status": 500,
                     "detail": "Error while attempting to insert new run report mapping",
                 },
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
     ]
@@ -102,7 +104,8 @@ def test_create_map(create_map_data):
                     "created_by": "rogelio@example.com",
                     "finished_at": "2020-09-24T19:09:59.311462",
                 },
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
         {
@@ -127,7 +130,8 @@ def test_create_map(create_map_data):
                     "status": 404,
                     "detail": "No run_report mapping found with the specified parameters",
                 },
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
     ]
@@ -177,7 +181,8 @@ def test_find_maps(find_maps_data):
                     "created_by": "rogelio@example.com",
                     "finished_at": "2020-09-24T21:07:59.311462",
                 },
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
         {
@@ -189,7 +194,8 @@ def test_find_maps(find_maps_data):
                     "status": 404,
                     "detail": "No run_report mapping found with the specified ID",
                 },
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
     ]
@@ -217,8 +223,7 @@ def test_find_maps_by_id(find_map_by_ids_data):
             "run_id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
             "report_id": "3d1bfbab-d9ec-46c7-aa8e-9c1d1808f2b8",
             "return": json.dumps(
-                {"message": "Successfully deleted 1 row"},
-                indent=4, sort_keys=True
+                {"message": "Successfully deleted 1 row"}, indent=4, sort_keys=True
             ),
         },
         {
@@ -230,7 +235,8 @@ def test_find_maps_by_id(find_map_by_ids_data):
                     "status": 404,
                     "detail": "No run_report mapping found with the specified ID",
                 },
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
     ]

--- a/tests/unit/rest/test_runs.py
+++ b/tests/unit/rest/test_runs.py
@@ -30,7 +30,8 @@ def unstub():
                     "test_id": "3d1bfbab-d9ec-46c7-aa8e-9c1d1808f2b8",
                     "run_id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
                 },
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
         {
@@ -41,7 +42,8 @@ def unstub():
                     "status": 404,
                     "detail": "No run found with the specified ID",
                 },
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
     ]
@@ -99,7 +101,8 @@ def test_find_by_id(find_by_id_data):
                         "run_id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
                     }
                 ],
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
         {
@@ -127,7 +130,8 @@ def test_find_by_id(find_by_id_data):
                     "status": 404,
                     "detail": "No runs found with the specified parameters",
                 },
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
     ]
@@ -171,8 +175,7 @@ def test_find(find_data):
         {
             "id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
             "return": json.dumps(
-                {"message": "Successfully deleted 1 row"},
-                indent=4, sort_keys=True
+                {"message": "Successfully deleted 1 row"}, indent=4, sort_keys=True
             ),
         },
         {
@@ -183,7 +186,8 @@ def test_find(find_data):
                     "status": 404,
                     "detail": "No run found with the specified ID",
                 },
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
     ]

--- a/tests/unit/rest/test_runs.py
+++ b/tests/unit/rest/test_runs.py
@@ -1,4 +1,4 @@
-import pprint
+import json
 
 import mockito
 import pytest
@@ -15,7 +15,7 @@ def unstub():
     params=[
         {
             "id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 {
                     "created_at": "2020-09-16T18:48:06.371563",
                     "finished_at": None,
@@ -29,17 +29,19 @@ def unstub():
                     "name": "Sword of Protection run",
                     "test_id": "3d1bfbab-d9ec-46c7-aa8e-9c1d1808f2b8",
                     "run_id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
-                }
+                },
+                indent=4, sort_keys=True
             ),
         },
         {
             "id": "3d1bfbab-d9ec-46c7-aa8e-9c1d1808f2b8",
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 {
                     "title": "No run found",
                     "status": 404,
                     "detail": "No run found with the specified ID",
-                }
+                },
+                indent=4, sort_keys=True
             ),
         },
     ]
@@ -80,7 +82,7 @@ def test_find_by_id(find_by_id_data):
                 ("limit", ""),
                 ("offset", ""),
             ],
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 [
                     {
                         "created_at": "2020-09-16T18:48:06.371563",
@@ -96,7 +98,8 @@ def test_find_by_id(find_by_id_data):
                         "test_id": "3d1bfbab-d9ec-46c7-aa8e-9c1d1808f2b8",
                         "run_id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
                     }
-                ]
+                ],
+                indent=4, sort_keys=True
             ),
         },
         {
@@ -118,12 +121,13 @@ def test_find_by_id(find_by_id_data):
                 ("limit", ""),
                 ("offset", ""),
             ],
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 {
                     "title": "No runs found",
                     "status": 404,
                     "detail": "No runs found with the specified parameters",
-                }
+                },
+                indent=4, sort_keys=True
             ),
         },
     ]
@@ -166,18 +170,20 @@ def test_find(find_data):
     params=[
         {
             "id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
-            "return": pprint.PrettyPrinter().pformat(
-                {"message": "Successfully deleted 1 row"}
+            "return": json.dumps(
+                {"message": "Successfully deleted 1 row"},
+                indent=4, sort_keys=True
             ),
         },
         {
             "id": "3d1bfbab-d9ec-46c7-aa8e-9c1d1808f2b8",
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 {
                     "title": "No run found",
                     "status": 404,
                     "detail": "No run found with the specified ID",
-                }
+                },
+                indent=4, sort_keys=True
             ),
         },
     ]

--- a/tests/unit/rest/test_software.py
+++ b/tests/unit/rest/test_software.py
@@ -24,7 +24,8 @@ def unstub():
                     "name": "Sword of Protection software",
                     "software_id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
                 },
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
         {
@@ -35,7 +36,8 @@ def unstub():
                     "status": 404,
                     "detail": "No software found with the specified ID",
                 },
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
     ]
@@ -81,7 +83,8 @@ def test_find_by_id(find_by_id_data):
                         "software_id": "bd132568-06fe-4b1a-9e96-47d4f36bf819",
                     }
                 ],
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
         {
@@ -103,7 +106,8 @@ def test_find_by_id(find_by_id_data):
                     "status": 404,
                     "detail": "No software found with the specified parameters",
                 },
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
     ]
@@ -152,7 +156,8 @@ def test_find(find_data):
                     "name": "Horde Emperor software",
                     "software_id": "bd132568-06fe-4b1a-9e96-47d4f36bf819",
                 },
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
         {
@@ -168,7 +173,8 @@ def test_find(find_data):
                     "status": 500,
                     "detail": "Error while attempting to insert new software",
                 },
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
     ]
@@ -213,7 +219,8 @@ def test_create(create_data):
                     "name": "Catra software",
                     "software_id": "bd132568-06fe-4b1a-9e96-47d4f36bf819",
                 },
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
         {
@@ -225,7 +232,8 @@ def test_create(create_data):
                     "status": 500,
                     "detail": "Error while attempting to update new software",
                 },
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
     ]

--- a/tests/unit/rest/test_software.py
+++ b/tests/unit/rest/test_software.py
@@ -1,4 +1,4 @@
-import pprint
+import json
 
 import mockito
 import pytest
@@ -15,7 +15,7 @@ def unstub():
     params=[
         {
             "id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 {
                     "created_at": "2020-09-16T18:48:06.371563",
                     "created_by": "adora@example.com",
@@ -23,17 +23,19 @@ def unstub():
                     "description": "This software will save Etheria",
                     "name": "Sword of Protection software",
                     "software_id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
-                }
+                },
+                indent=4, sort_keys=True
             ),
         },
         {
             "id": "3d1bfbab-d9ec-46c7-aa8e-9c1d1808f2b8",
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 {
                     "title": "No software found",
                     "status": 404,
                     "detail": "No software found with the specified ID",
-                }
+                },
+                indent=4, sort_keys=True
             ),
         },
     ]
@@ -68,7 +70,7 @@ def test_find_by_id(find_by_id_data):
                 ("limit", ""),
                 ("offset", ""),
             ],
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 [
                     {
                         "created_at": "2020-09-16T18:48:08.371563",
@@ -78,7 +80,8 @@ def test_find_by_id(find_by_id_data):
                         "name": "Queen of Bright Moon software",
                         "software_id": "bd132568-06fe-4b1a-9e96-47d4f36bf819",
                     }
-                ]
+                ],
+                indent=4, sort_keys=True
             ),
         },
         {
@@ -94,12 +97,13 @@ def test_find_by_id(find_by_id_data):
                 ("limit", ""),
                 ("offset", ""),
             ],
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 {
                     "title": "No software found",
                     "status": 404,
                     "detail": "No software found with the specified parameters",
-                }
+                },
+                indent=4, sort_keys=True
             ),
         },
     ]
@@ -139,7 +143,7 @@ def test_find(find_data):
                 ("repository_url", "example.com/hordeemperor"),
                 ("created_by", "hordeprime@example.com"),
             ],
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 {
                     "created_at": "2020-09-16T18:48:08.371563",
                     "created_by": "hordeprime@example.com",
@@ -147,7 +151,8 @@ def test_find(find_data):
                     "description": "This software rules the known universe",
                     "name": "Horde Emperor software",
                     "software_id": "bd132568-06fe-4b1a-9e96-47d4f36bf819",
-                }
+                },
+                indent=4, sort_keys=True
             ),
         },
         {
@@ -157,12 +162,13 @@ def test_find(find_data):
                 ("repository_url", "example.com/hordeemperor"),
                 ("created_by", "hordeprime@example.com"),
             ],
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 {
                     "title": "Server error",
                     "status": 500,
                     "detail": "Error while attempting to insert new software",
-                }
+                },
+                indent=4, sort_keys=True
             ),
         },
     ]
@@ -198,7 +204,7 @@ def test_create(create_data):
                     "This software is trying to learn to process anger better",
                 ),
             ],
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 {
                     "created_at": "2020-09-16T18:48:08.371563",
                     "created_by": "catra@example.com",
@@ -206,18 +212,20 @@ def test_create(create_data):
                     "description": "This software is trying to learn to process anger better",
                     "name": "Catra software",
                     "software_id": "bd132568-06fe-4b1a-9e96-47d4f36bf819",
-                }
+                },
+                indent=4, sort_keys=True
             ),
         },
         {
             "id": "98536487-06fe-4b1a-9e96-47d4f36bf819",
             "params": [("name", "Angella software"), ("description", "")],
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 {
                     "title": "Server error",
                     "status": 500,
                     "detail": "Error while attempting to update new software",
-                }
+                },
+                indent=4, sort_keys=True
             ),
         },
     ]

--- a/tests/unit/rest/test_software_builds.py
+++ b/tests/unit/rest/test_software_builds.py
@@ -25,7 +25,8 @@ def unstub():
                     "software_version_id": "3d1bfbab-d9ec-46c7-aa8e-9c1d1808f2b8",
                     "software_build_id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
                 },
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
         {
@@ -36,7 +37,8 @@ def unstub():
                     "status": 404,
                     "detail": "No software_build found with the specified ID",
                 },
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
     ]
@@ -85,7 +87,8 @@ def test_find_by_id(find_by_id_data):
                         "software_build_id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
                     }
                 ],
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
         {
@@ -109,7 +112,8 @@ def test_find_by_id(find_by_id_data):
                     "status": 404,
                     "detail": "No software_builds found with the specified parameters",
                 },
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
     ]

--- a/tests/unit/rest/test_software_builds.py
+++ b/tests/unit/rest/test_software_builds.py
@@ -1,4 +1,4 @@
-import pprint
+import json
 
 import mockito
 import pytest
@@ -15,7 +15,7 @@ def unstub():
     params=[
         {
             "id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 {
                     "created_at": "2020-09-16T18:48:06.371563",
                     "status": "submitted",
@@ -24,17 +24,19 @@ def unstub():
                     "build_job_id": "d041bcce-288f-4c7e-9f9d-b6af57ae2369",
                     "software_version_id": "3d1bfbab-d9ec-46c7-aa8e-9c1d1808f2b8",
                     "software_build_id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
-                }
+                },
+                indent=4, sort_keys=True
             ),
         },
         {
             "id": "3d1bfbab-d9ec-46c7-aa8e-9c1d1808f2b8",
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 {
                     "title": "No software_build found",
                     "status": 404,
                     "detail": "No software_build found with the specified ID",
-                }
+                },
+                indent=4, sort_keys=True
             ),
         },
     ]
@@ -71,7 +73,7 @@ def test_find_by_id(find_by_id_data):
                 ("limit", ""),
                 ("offset", ""),
             ],
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 [
                     {
                         "created_at": "2020-09-16T18:48:06.371563",
@@ -82,7 +84,8 @@ def test_find_by_id(find_by_id_data):
                         "software_version_id": "3d1bfbab-d9ec-46c7-aa8e-9c1d1808f2b8",
                         "software_build_id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
                     }
-                ]
+                ],
+                indent=4, sort_keys=True
             ),
         },
         {
@@ -100,12 +103,13 @@ def test_find_by_id(find_by_id_data):
                 ("limit", ""),
                 ("offset", ""),
             ],
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 {
                     "title": "No software_builds found",
                     "status": 404,
                     "detail": "No software_builds found with the specified parameters",
-                }
+                },
+                indent=4, sort_keys=True
             ),
         },
     ]

--- a/tests/unit/rest/test_software_versions.py
+++ b/tests/unit/rest/test_software_versions.py
@@ -1,4 +1,4 @@
-import pprint
+import json
 
 import mockito
 import pytest
@@ -15,23 +15,25 @@ def unstub():
     params=[
         {
             "id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 {
                     "created_at": "2020-09-16T18:48:06.371563",
                     "commit": "ca82a6dff817ec66f44342007202690a93763949",
                     "software_id": "3d1bfbab-d9ec-46c7-aa8e-9c1d1808f2b8",
                     "software_version_id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
-                }
+                },
+                indent=4, sort_keys=True
             ),
         },
         {
             "id": "3d1bfbab-d9ec-46c7-aa8e-9c1d1808f2b8",
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 {
                     "title": "No software_version found",
                     "status": 404,
                     "detail": "No software_version found with the specified ID",
-                }
+                },
+                indent=4, sort_keys=True
             ),
         },
     ]
@@ -65,7 +67,7 @@ def test_find_by_id(find_by_id_data):
                 ("limit", ""),
                 ("offset", ""),
             ],
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 [
                     {
                         "created_at": "2020-09-16T18:48:06.371563",
@@ -73,7 +75,8 @@ def test_find_by_id(find_by_id_data):
                         "software_id": "3d1bfbab-d9ec-46c7-aa8e-9c1d1808f2b8",
                         "software_version_id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
                     }
-                ]
+                ],
+                indent=4, sort_keys=True
             ),
         },
         {
@@ -88,12 +91,13 @@ def test_find_by_id(find_by_id_data):
                 ("limit", ""),
                 ("offset", ""),
             ],
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 {
                     "title": "No software_versions found",
                     "status": 404,
                     "detail": "No software_versions found with the specified parameters",
-                }
+                },
+                indent=4, sort_keys=True
             ),
         },
     ]

--- a/tests/unit/rest/test_software_versions.py
+++ b/tests/unit/rest/test_software_versions.py
@@ -22,7 +22,8 @@ def unstub():
                     "software_id": "3d1bfbab-d9ec-46c7-aa8e-9c1d1808f2b8",
                     "software_version_id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
                 },
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
         {
@@ -33,7 +34,8 @@ def unstub():
                     "status": 404,
                     "detail": "No software_version found with the specified ID",
                 },
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
     ]
@@ -76,7 +78,8 @@ def test_find_by_id(find_by_id_data):
                         "software_version_id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
                     }
                 ],
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
         {
@@ -97,7 +100,8 @@ def test_find_by_id(find_by_id_data):
                     "status": 404,
                     "detail": "No software_versions found with the specified parameters",
                 },
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
     ]

--- a/tests/unit/rest/test_subscriptions.py
+++ b/tests/unit/rest/test_subscriptions.py
@@ -1,4 +1,4 @@
-import pprint
+import json
 
 import mockito
 import pytest
@@ -15,24 +15,26 @@ def unstub():
     params=[
         {
             "id": "361b3b95-4a6e-40d9-bd98-f92b2959864e",
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 {
                     "subscription_id": "361b3b95-4a6e-40d9-bd98-f92b2959864e",
                     "entity_type": "template",
                     "entity_id": "047e27ad-2890-4372-b2cb-dfec57347eb9",
                     "email": "bow@example.com",
                     "created_at": "2020-09-23T19:41:46.839880",
-                }
+                },
+                indent=4, sort_keys=True
             ),
         },
         {
             "id": "3d1bfbab-d9ec-46c7-aa8e-9c1d1808f2b8",
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 {
                     "title": "No subscription found",
                     "status": 404,
                     "detail": "No subscription found with the specified ID",
-                }
+                },
+                indent=4, sort_keys=True
             ),
         },
     ]
@@ -66,7 +68,7 @@ def test_find_by_id(find_by_id_data):
                 ("limit", ""),
                 ("offset", ""),
             ],
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 [
                     {
                         "subscription_id": "361b3b95-4a6e-40d9-bd98-f92b2959864e",
@@ -75,7 +77,8 @@ def test_find_by_id(find_by_id_data):
                         "email": "scorpia@example.com",
                         "created_at": "2020-09-23T19:41:46.839880",
                     }
-                ]
+                ],
+                indent=4, sort_keys=True
             ),
         },
         {
@@ -90,12 +93,13 @@ def test_find_by_id(find_by_id_data):
                 ("limit", ""),
                 ("offset", ""),
             ],
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 {
                     "title": "No subscriptions found",
                     "status": 404,
                     "detail": "No subscriptions found with the specified parameters",
-                }
+                },
+                indent=4, sort_keys=True
             ),
         },
     ]

--- a/tests/unit/rest/test_subscriptions.py
+++ b/tests/unit/rest/test_subscriptions.py
@@ -23,7 +23,8 @@ def unstub():
                     "email": "bow@example.com",
                     "created_at": "2020-09-23T19:41:46.839880",
                 },
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
         {
@@ -34,7 +35,8 @@ def unstub():
                     "status": 404,
                     "detail": "No subscription found with the specified ID",
                 },
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
     ]
@@ -78,7 +80,8 @@ def test_find_by_id(find_by_id_data):
                         "created_at": "2020-09-23T19:41:46.839880",
                     }
                 ],
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
         {
@@ -99,7 +102,8 @@ def test_find_by_id(find_by_id_data):
                     "status": 404,
                     "detail": "No subscriptions found with the specified parameters",
                 },
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
     ]

--- a/tests/unit/rest/test_template_reports.py
+++ b/tests/unit/rest/test_template_reports.py
@@ -18,7 +18,8 @@ from carrot_cli.rest import request_handler, template_reports
                     "created_at": "2020-09-24T19:07:59.311462",
                     "created_by": "rogelio@example.com",
                 },
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
         {
@@ -31,7 +32,8 @@ from carrot_cli.rest import request_handler, template_reports
                     "status": 500,
                     "detail": "Error while attempting to insert new template report mapping",
                 },
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
     ]
@@ -82,7 +84,8 @@ def test_create_map(create_map_data):
                     "created_at": "2020-09-24T19:07:59.311462",
                     "created_by": "rogelio@example.com",
                 },
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
         {
@@ -102,7 +105,8 @@ def test_create_map(create_map_data):
                     "status": 404,
                     "detail": "No template_report mapping found with the specified parameters",
                 },
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
     ]
@@ -143,7 +147,8 @@ def test_find_maps(find_maps_data):
                     "created_at": "2020-09-24T19:07:59.311462",
                     "created_by": "rogelio@example.com",
                 },
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
         {
@@ -155,7 +160,8 @@ def test_find_maps(find_maps_data):
                     "status": 404,
                     "detail": "No template_report mapping found with the specified ID",
                 },
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
     ]
@@ -183,8 +189,7 @@ def test_find_maps_by_id(find_map_by_ids_data):
             "template_id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
             "report_id": "3d1bfbab-d9ec-46c7-aa8e-9c1d1808f2b8",
             "return": json.dumps(
-                {"message": "Successfully deleted 1 row"},
-                indent=4, sort_keys=True
+                {"message": "Successfully deleted 1 row"}, indent=4, sort_keys=True
             ),
         },
         {
@@ -196,7 +201,8 @@ def test_find_maps_by_id(find_map_by_ids_data):
                     "status": 404,
                     "detail": "No template_report mapping found with the specified ID",
                 },
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
     ]

--- a/tests/unit/rest/test_template_reports.py
+++ b/tests/unit/rest/test_template_reports.py
@@ -1,4 +1,4 @@
-import pprint
+import json
 
 import mockito
 import pytest
@@ -11,25 +11,27 @@ from carrot_cli.rest import request_handler, template_reports
             "template_id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
             "report_id": "3d1bfbab-d9ec-46c7-aa8e-9c1d1808f2b8",
             "created_by": "rogelio@example.com",
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 {
                     "template_id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
                     "report_id": "3d1bfbab-d9ec-46c7-aa8e-9c1d1808f2b8",
                     "created_at": "2020-09-24T19:07:59.311462",
                     "created_by": "rogelio@example.com",
-                }
+                },
+                indent=4, sort_keys=True
             ),
         },
         {
             "template_id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
             "report_id": "3d1bfbab-d9ec-46c7-aa8e-9c1d1808f2b8",
             "created_by": "rogelio@example.com",
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 {
                     "title": "Server error",
                     "status": 500,
                     "detail": "Error while attempting to insert new template report mapping",
-                }
+                },
+                indent=4, sort_keys=True
             ),
         },
     ]
@@ -73,13 +75,14 @@ def test_create_map(create_map_data):
                 ("limit", ""),
                 ("offset", ""),
             ],
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 {
                     "template_id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
                     "report_id": "3d1bfbab-d9ec-46c7-aa8e-9c1d1808f2b8",
                     "created_at": "2020-09-24T19:07:59.311462",
                     "created_by": "rogelio@example.com",
-                }
+                },
+                indent=4, sort_keys=True
             ),
         },
         {
@@ -93,12 +96,13 @@ def test_create_map(create_map_data):
                 ("limit", ""),
                 ("offset", ""),
             ],
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 {
                     "title": "No template_report mapping found",
                     "status": 404,
                     "detail": "No template_report mapping found with the specified parameters",
-                }
+                },
+                indent=4, sort_keys=True
             ),
         },
     ]
@@ -132,24 +136,26 @@ def test_find_maps(find_maps_data):
         {
             "template_id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
             "report_id": "3d1bfbab-d9ec-46c7-aa8e-9c1d1808f2b8",
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 {
                     "template_id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
                     "report_id": "3d1bfbab-d9ec-46c7-aa8e-9c1d1808f2b8",
                     "created_at": "2020-09-24T19:07:59.311462",
                     "created_by": "rogelio@example.com",
-                }
+                },
+                indent=4, sort_keys=True
             ),
         },
         {
             "template_id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
             "report_id": "3d1bfbab-d9ec-46c7-aa8e-9c1d1808f2b8",
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 {
                     "title": "No template_report mapping found",
                     "status": 404,
                     "detail": "No template_report mapping found with the specified ID",
-                }
+                },
+                indent=4, sort_keys=True
             ),
         },
     ]
@@ -176,19 +182,21 @@ def test_find_maps_by_id(find_map_by_ids_data):
         {
             "template_id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
             "report_id": "3d1bfbab-d9ec-46c7-aa8e-9c1d1808f2b8",
-            "return": pprint.PrettyPrinter().pformat(
-                {"message": "Successfully deleted 1 row"}
+            "return": json.dumps(
+                {"message": "Successfully deleted 1 row"},
+                indent=4, sort_keys=True
             ),
         },
         {
             "template_id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
             "report_id": "3d1bfbab-d9ec-46c7-aa8e-9c1d1808f2b8",
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 {
                     "title": "No template_report mapping found",
                     "status": 404,
                     "detail": "No template_report mapping found with the specified ID",
-                }
+                },
+                indent=4, sort_keys=True
             ),
         },
     ]

--- a/tests/unit/rest/test_template_results.py
+++ b/tests/unit/rest/test_template_results.py
@@ -20,7 +20,8 @@ from carrot_cli.rest import request_handler, template_results
                     "created_at": "2020-09-24T19:07:59.311462",
                     "created_by": "rogelio@example.com",
                 },
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
         {
@@ -34,7 +35,8 @@ from carrot_cli.rest import request_handler, template_results
                     "status": 500,
                     "detail": "Error while attempting to insert new template result mapping",
                 },
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
     ]
@@ -89,7 +91,8 @@ def test_create_map(create_map_data):
                     "created_at": "2020-09-24T19:07:59.311462",
                     "created_by": "rogelio@example.com",
                 },
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
         {
@@ -110,7 +113,8 @@ def test_create_map(create_map_data):
                     "status": 404,
                     "detail": "No template_result mapping found with the specified parameters",
                 },
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
     ]
@@ -153,7 +157,8 @@ def test_find_maps(find_maps_data):
                     "created_at": "2020-09-24T19:07:59.311462",
                     "created_by": "rogelio@example.com",
                 },
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
         {
@@ -165,7 +170,8 @@ def test_find_maps(find_maps_data):
                     "status": 404,
                     "detail": "No template_result mapping found with the specified ID",
                 },
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
     ]
@@ -193,8 +199,7 @@ def test_find_maps_by_id(find_map_by_ids_data):
             "template_id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
             "result_id": "3d1bfbab-d9ec-46c7-aa8e-9c1d1808f2b8",
             "return": json.dumps(
-                {"message": "Successfully deleted 1 row"},
-                indent=4, sort_keys=True
+                {"message": "Successfully deleted 1 row"}, indent=4, sort_keys=True
             ),
         },
         {
@@ -206,7 +211,8 @@ def test_find_maps_by_id(find_map_by_ids_data):
                     "status": 404,
                     "detail": "No template_result mapping found with the specified ID",
                 },
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
     ]

--- a/tests/unit/rest/test_template_results.py
+++ b/tests/unit/rest/test_template_results.py
@@ -1,4 +1,4 @@
-import pprint
+import json
 
 import mockito
 import pytest
@@ -12,14 +12,15 @@ from carrot_cli.rest import request_handler, template_results
             "result_id": "3d1bfbab-d9ec-46c7-aa8e-9c1d1808f2b8",
             "result_key": "out_horde_tanks",
             "created_by": "rogelio@example.com",
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 {
                     "template_id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
                     "result_id": "3d1bfbab-d9ec-46c7-aa8e-9c1d1808f2b8",
                     "result_key": "out_horde_tanks",
                     "created_at": "2020-09-24T19:07:59.311462",
                     "created_by": "rogelio@example.com",
-                }
+                },
+                indent=4, sort_keys=True
             ),
         },
         {
@@ -27,12 +28,13 @@ from carrot_cli.rest import request_handler, template_results
             "result_id": "3d1bfbab-d9ec-46c7-aa8e-9c1d1808f2b8",
             "result_key": "out_horde_tanks",
             "created_by": "rogelio@example.com",
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 {
                     "title": "Server error",
                     "status": 500,
                     "detail": "Error while attempting to insert new template result mapping",
-                }
+                },
+                indent=4, sort_keys=True
             ),
         },
     ]
@@ -79,14 +81,15 @@ def test_create_map(create_map_data):
                 ("limit", ""),
                 ("offset", ""),
             ],
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 {
                     "template_id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
                     "result_id": "3d1bfbab-d9ec-46c7-aa8e-9c1d1808f2b8",
                     "result_key": "out_horde_tanks",
                     "created_at": "2020-09-24T19:07:59.311462",
                     "created_by": "rogelio@example.com",
-                }
+                },
+                indent=4, sort_keys=True
             ),
         },
         {
@@ -101,12 +104,13 @@ def test_create_map(create_map_data):
                 ("limit", ""),
                 ("offset", ""),
             ],
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 {
                     "title": "No template_result mapping found",
                     "status": 404,
                     "detail": "No template_result mapping found with the specified parameters",
-                }
+                },
+                indent=4, sort_keys=True
             ),
         },
     ]
@@ -141,25 +145,27 @@ def test_find_maps(find_maps_data):
         {
             "template_id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
             "result_id": "3d1bfbab-d9ec-46c7-aa8e-9c1d1808f2b8",
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 {
                     "template_id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
                     "result_id": "3d1bfbab-d9ec-46c7-aa8e-9c1d1808f2b8",
                     "result_key": "out_horde_tanks",
                     "created_at": "2020-09-24T19:07:59.311462",
                     "created_by": "rogelio@example.com",
-                }
+                },
+                indent=4, sort_keys=True
             ),
         },
         {
             "template_id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
             "result_id": "3d1bfbab-d9ec-46c7-aa8e-9c1d1808f2b8",
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 {
                     "title": "No template_result mapping found",
                     "status": 404,
                     "detail": "No template_result mapping found with the specified ID",
-                }
+                },
+                indent=4, sort_keys=True
             ),
         },
     ]
@@ -186,19 +192,21 @@ def test_find_maps_by_id(find_map_by_ids_data):
         {
             "template_id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
             "result_id": "3d1bfbab-d9ec-46c7-aa8e-9c1d1808f2b8",
-            "return": pprint.PrettyPrinter().pformat(
-                {"message": "Successfully deleted 1 row"}
+            "return": json.dumps(
+                {"message": "Successfully deleted 1 row"},
+                indent=4, sort_keys=True
             ),
         },
         {
             "template_id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
             "result_id": "3d1bfbab-d9ec-46c7-aa8e-9c1d1808f2b8",
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 {
                     "title": "No template_result mapping found",
                     "status": 404,
                     "detail": "No template_result mapping found with the specified ID",
-                }
+                },
+                indent=4, sort_keys=True
             ),
         },
     ]

--- a/tests/unit/rest/test_templates.py
+++ b/tests/unit/rest/test_templates.py
@@ -1,4 +1,4 @@
-import pprint
+import json
 
 import mockito
 import pytest
@@ -15,7 +15,7 @@ def unstub():
     params=[
         {
             "id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 {
                     "created_at": "2020-09-16T18:48:06.371563",
                     "created_by": "adora@example.com",
@@ -25,17 +25,19 @@ def unstub():
                     "name": "Sword of Protection template",
                     "pipeline_id": "3d1bfbab-d9ec-46c7-aa8e-9c1d1808f2b8",
                     "template_id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
-                }
+                },
+                indent=4, sort_keys=True
             ),
         },
         {
             "id": "3d1bfbab-d9ec-46c7-aa8e-9c1d1808f2b8",
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 {
                     "title": "No template found",
                     "status": 404,
                     "detail": "No template found with the specified ID",
-                }
+                },
+                indent=4, sort_keys=True
             ),
         },
     ]
@@ -73,7 +75,7 @@ def test_find_by_id(find_by_id_data):
                 ("limit", ""),
                 ("offset", ""),
             ],
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 [
                     {
                         "created_at": "2020-09-16T18:48:08.371563",
@@ -85,7 +87,8 @@ def test_find_by_id(find_by_id_data):
                         "pipeline_id": "58723b05-6060-4444-9f1b-394aff691cce",
                         "template_id": "bd132568-06fe-4b1a-9e96-47d4f36bf819",
                     }
-                ]
+                ],
+                indent=4, sort_keys=True
             ),
         },
         {
@@ -104,12 +107,13 @@ def test_find_by_id(find_by_id_data):
                 ("limit", ""),
                 ("offset", ""),
             ],
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 {
                     "title": "No templates found",
                     "status": 404,
                     "detail": "No templates found with the specified parameters",
-                }
+                },
+                indent=4, sort_keys=True
             ),
         },
     ]
@@ -154,7 +158,7 @@ def test_find(find_data):
                 ("eval_wdl", "example.com/horde_eval.wdl"),
                 ("created_by", "hordeprime@example.com"),
             ],
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 {
                     "created_at": "2020-09-16T18:48:08.371563",
                     "created_by": "hordeprime@example.com",
@@ -164,7 +168,8 @@ def test_find(find_data):
                     "name": "Horde Emperor template",
                     "pipeline_id": "9d1bfbab-d9ec-46c7-aa8e-9c1d1808f2b8",
                     "template_id": "bd132568-06fe-4b1a-9e96-47d4f36bf819",
-                }
+                },
+                indent=4, sort_keys=True
             ),
         },
         {
@@ -176,12 +181,13 @@ def test_find(find_data):
                 ("eval_wdl", "example.com/horde_eval.wdl"),
                 ("created_by", "hordeprime@example.com"),
             ],
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 {
                     "title": "Server error",
                     "status": 500,
                     "detail": "Error while attempting to insert new template",
-                }
+                },
+                indent=4, sort_keys=True
             ),
         },
     ]
@@ -221,7 +227,7 @@ def test_create(create_data):
                 ("test_wdl", "example.com/horde_test.wdl"),
                 ("eval_wdl", "example.com/horde_eval.wdl"),
             ],
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 {
                     "created_at": "2020-09-16T18:48:08.371563",
                     "created_by": "catra@example.com",
@@ -231,7 +237,8 @@ def test_create(create_data):
                     "name": "Catra template",
                     "pipeline_id": "98536487-06fe-4b1a-9e96-47d4f36bf819",
                     "template_id": "bd132568-06fe-4b1a-9e96-47d4f36bf819",
-                }
+                },
+                indent=4, sort_keys=True
             ),
         },
         {
@@ -242,12 +249,13 @@ def test_create(create_data):
                 ("test_wdl", ""),
                 ("eval_wdl", ""),
             ],
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 {
                     "title": "Server error",
                     "status": 500,
                     "detail": "Error while attempting to update template",
-                }
+                },
+                indent=4, sort_keys=True
             ),
         },
     ]
@@ -277,18 +285,20 @@ def test_update(update_data):
     params=[
         {
             "id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
-            "return": pprint.PrettyPrinter().pformat(
-                {"message": "Successfully deleted 1 row"}
+            "return": json.dumps(
+                {"message": "Successfully deleted 1 row"},
+                indent=4, sort_keys=True
             ),
         },
         {
             "id": "3d1bfbab-d9ec-46c7-aa8e-9c1d1808f2b8",
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 {
                     "title": "No template found",
                     "status": 404,
                     "detail": "No template found with the specified ID",
-                }
+                },
+                indent=4, sort_keys=True
             ),
         },
     ]
@@ -313,25 +323,27 @@ def test_delete(delete_data):
         {
             "id": "047e27ad-2890-4372-b2cb-dfec57347eb9",
             "email": "bow@example.com",
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 {
                     "subscription_id": "361b3b95-4a6e-40d9-bd98-f92b2959864e",
                     "entity_type": "template",
                     "entity_id": "047e27ad-2890-4372-b2cb-dfec57347eb9",
                     "email": "bow@example.com",
                     "created_at": "2020-09-23T19:41:46.839880",
-                }
+                },
+                indent=4, sort_keys=True
             ),
         },
         {
             "id": "98536487-06fe-4b1a-9e96-47d4f36bf819",
             "email": "huntara@example.com",
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 {
                     "title": "No template found",
                     "status": 404,
                     "detail": "No template found with the specified ID",
-                }
+                },
+                indent=4, sort_keys=True
             ),
         },
     ]
@@ -359,19 +371,21 @@ def test_subscribe(subscribe_data):
         {
             "id": "047e27ad-2890-4372-b2cb-dfec57347eb9",
             "email": "mermista@example.com",
-            "return": pprint.PrettyPrinter().pformat(
-                {"message": "Successfully deleted 1 row(s)"}
+            "return": json.dumps(
+                {"message": "Successfully deleted 1 row(s)"},
+                indent=4, sort_keys=True
             ),
         },
         {
             "id": "98536487-06fe-4b1a-9e96-47d4f36bf819",
             "email": "castaspella@example.com",
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 {
                     "title": "No subscription found",
                     "status": 404,
                     "detail": "No subscription found for the specified parameters",
-                }
+                },
+                indent=4, sort_keys=True
             ),
         },
     ]

--- a/tests/unit/rest/test_templates.py
+++ b/tests/unit/rest/test_templates.py
@@ -26,7 +26,8 @@ def unstub():
                     "pipeline_id": "3d1bfbab-d9ec-46c7-aa8e-9c1d1808f2b8",
                     "template_id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
                 },
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
         {
@@ -37,7 +38,8 @@ def unstub():
                     "status": 404,
                     "detail": "No template found with the specified ID",
                 },
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
     ]
@@ -88,7 +90,8 @@ def test_find_by_id(find_by_id_data):
                         "template_id": "bd132568-06fe-4b1a-9e96-47d4f36bf819",
                     }
                 ],
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
         {
@@ -113,7 +116,8 @@ def test_find_by_id(find_by_id_data):
                     "status": 404,
                     "detail": "No templates found with the specified parameters",
                 },
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
     ]
@@ -169,7 +173,8 @@ def test_find(find_data):
                     "pipeline_id": "9d1bfbab-d9ec-46c7-aa8e-9c1d1808f2b8",
                     "template_id": "bd132568-06fe-4b1a-9e96-47d4f36bf819",
                 },
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
         {
@@ -187,7 +192,8 @@ def test_find(find_data):
                     "status": 500,
                     "detail": "Error while attempting to insert new template",
                 },
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
     ]
@@ -238,7 +244,8 @@ def test_create(create_data):
                     "pipeline_id": "98536487-06fe-4b1a-9e96-47d4f36bf819",
                     "template_id": "bd132568-06fe-4b1a-9e96-47d4f36bf819",
                 },
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
         {
@@ -255,7 +262,8 @@ def test_create(create_data):
                     "status": 500,
                     "detail": "Error while attempting to update template",
                 },
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
     ]
@@ -286,8 +294,7 @@ def test_update(update_data):
         {
             "id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
             "return": json.dumps(
-                {"message": "Successfully deleted 1 row"},
-                indent=4, sort_keys=True
+                {"message": "Successfully deleted 1 row"}, indent=4, sort_keys=True
             ),
         },
         {
@@ -298,7 +305,8 @@ def test_update(update_data):
                     "status": 404,
                     "detail": "No template found with the specified ID",
                 },
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
     ]
@@ -331,7 +339,8 @@ def test_delete(delete_data):
                     "email": "bow@example.com",
                     "created_at": "2020-09-23T19:41:46.839880",
                 },
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
         {
@@ -343,7 +352,8 @@ def test_delete(delete_data):
                     "status": 404,
                     "detail": "No template found with the specified ID",
                 },
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
     ]
@@ -372,8 +382,7 @@ def test_subscribe(subscribe_data):
             "id": "047e27ad-2890-4372-b2cb-dfec57347eb9",
             "email": "mermista@example.com",
             "return": json.dumps(
-                {"message": "Successfully deleted 1 row(s)"},
-                indent=4, sort_keys=True
+                {"message": "Successfully deleted 1 row(s)"}, indent=4, sort_keys=True
             ),
         },
         {
@@ -385,7 +394,8 @@ def test_subscribe(subscribe_data):
                     "status": 404,
                     "detail": "No subscription found for the specified parameters",
                 },
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
     ]

--- a/tests/unit/rest/test_tests.py
+++ b/tests/unit/rest/test_tests.py
@@ -1,4 +1,4 @@
-import pprint
+import json
 
 import mockito
 import pytest
@@ -15,7 +15,7 @@ def unstub():
     params=[
         {
             "id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 {
                     "created_at": "2020-09-16T18:48:06.371563",
                     "created_by": "adora@example.com",
@@ -25,17 +25,19 @@ def unstub():
                     "name": "Sword of Protection test",
                     "template_id": "3d1bfbab-d9ec-46c7-aa8e-9c1d1808f2b8",
                     "test_id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
-                }
+                },
+                indent=4, sort_keys=True
             ),
         },
         {
             "id": "3d1bfbab-d9ec-46c7-aa8e-9c1d1808f2b8",
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 {
                     "title": "No test found",
                     "status": 404,
                     "detail": "No test found with the specified ID",
-                }
+                },
+                indent=4, sort_keys=True
             ),
         },
     ]
@@ -73,7 +75,7 @@ def test_find_by_id(find_by_id_data):
                 ("limit", ""),
                 ("offset", ""),
             ],
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 [
                     {
                         "created_at": "2020-09-16T18:48:08.371563",
@@ -85,7 +87,8 @@ def test_find_by_id(find_by_id_data):
                         "template_id": "58723b05-6060-4444-9f1b-394aff691cce",
                         "test_id": "bd132568-06fe-4b1a-9e96-47d4f36bf819",
                     }
-                ]
+                ],
+                indent=4, sort_keys=True
             ),
         },
         {
@@ -104,12 +107,13 @@ def test_find_by_id(find_by_id_data):
                 ("limit", ""),
                 ("offset", ""),
             ],
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 {
                     "title": "No tests found",
                     "status": 404,
                     "detail": "No tests found with the specified parameters",
-                }
+                },
+                indent=4, sort_keys=True
             ),
         },
     ]
@@ -154,7 +158,7 @@ def test_find(find_data):
                 ("eval_input_defaults", {"in_brother": "Hordak"}),
                 ("created_by", "hordeprime@example.com"),
             ],
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 {
                     "created_at": "2020-09-16T18:48:08.371563",
                     "created_by": "hordeprime@example.com",
@@ -164,7 +168,8 @@ def test_find(find_data):
                     "name": "Horde Emperor test",
                     "template_id": "9d1bfbab-d9ec-46c7-aa8e-9c1d1808f2b8",
                     "test_id": "bd132568-06fe-4b1a-9e96-47d4f36bf819",
-                }
+                },
+                indent=4, sort_keys=True
             ),
         },
         {
@@ -176,12 +181,13 @@ def test_find(find_data):
                 ("eval_input_defaults", {"in_brother": "Hordak"}),
                 ("created_by", "hordeprime@example.com"),
             ],
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 {
                     "title": "Server error",
                     "status": 500,
                     "detail": "Error while attempting to insert new test",
-                }
+                },
+                indent=4, sort_keys=True
             ),
         },
     ]
@@ -218,7 +224,7 @@ def test_create(create_data):
                 ("test_input_defaults", {"in_nemesis?": "She-Ra"}),
                 ("eval_input_defaults", {"in_mother_figure": "Shadow Weaver"}),
             ],
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 {
                     "created_at": "2020-09-16T18:48:08.371563",
                     "created_by": "catra@example.com",
@@ -228,7 +234,8 @@ def test_create(create_data):
                     "name": "Catra test",
                     "template_id": "98536487-06fe-4b1a-9e96-47d4f36bf819",
                     "test_id": "bd132568-06fe-4b1a-9e96-47d4f36bf819",
-                }
+                },
+                indent=4, sort_keys=True
             ),
         },
         {
@@ -239,12 +246,13 @@ def test_create(create_data):
                 ("test_input_defaults", ""),
                 ("eval_input_defaults", ""),
             ],
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 {
                     "title": "Server error",
                     "status": 500,
                     "detail": "Error while attempting to update test",
-                }
+                },
+                indent=4, sort_keys=True
             ),
         },
     ]
@@ -274,18 +282,20 @@ def test_update(update_data):
     params=[
         {
             "id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
-            "return": pprint.PrettyPrinter().pformat(
-                {"message": "Successfully deleted 1 row"}
+            "return": json.dumps(
+                {"message": "Successfully deleted 1 row"},
+                indent=4, sort_keys=True
             ),
         },
         {
             "id": "3d1bfbab-d9ec-46c7-aa8e-9c1d1808f2b8",
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 {
                     "title": "No test found",
                     "status": 404,
                     "detail": "No test found with the specified ID",
-                }
+                },
+                indent=4, sort_keys=True
             ),
         },
     ]
@@ -315,7 +325,7 @@ def test_delete(delete_data):
                 ("eval_input", {"in_wife": "Angella"}),
                 ("created_by", "micah@example.com"),
             ],
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 {
                     "run_id": "69717609-0e95-4c9c-965c-1ea40a2cf44f",
                     "test_id": "c97c25e5-4adf-4db7-8f64-19af34d84ef8",
@@ -327,7 +337,8 @@ def test_delete(delete_data):
                     "created_at": "2020-09-24T15:50:49.641333",
                     "created_by": "micah@example.com",
                     "finished_at": None,
-                }
+                },
+                indent=4, sort_keys=True
             ),
         },
         {
@@ -338,12 +349,13 @@ def test_delete(delete_data):
                 ("eval_input", {"likes": "Plants, Mindfulness"}),
                 ("created_by", "perfuma@example.com"),
             ],
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 {
                     "title": "Server error",
                     "status": 500,
                     "detail": "Error while attempting to query the database: NotFound",
-                }
+                },
+                indent=4, sort_keys=True
             ),
         },
     ]
@@ -374,25 +386,27 @@ def test_run(run_data):
         {
             "id": "047e27ad-2890-4372-b2cb-dfec57347eb9",
             "email": "bow@example.com",
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 {
                     "subscription_id": "361b3b95-4a6e-40d9-bd98-f92b2959864e",
                     "entity_type": "test",
                     "entity_id": "047e27ad-2890-4372-b2cb-dfec57347eb9",
                     "email": "bow@example.com",
                     "created_at": "2020-09-23T19:41:46.839880",
-                }
+                },
+                indent=4, sort_keys=True
             ),
         },
         {
             "id": "98536487-06fe-4b1a-9e96-47d4f36bf819",
             "email": "huntara@example.com",
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 {
                     "title": "No test found",
                     "status": 404,
                     "detail": "No test found with the specified ID",
-                }
+                },
+                indent=4, sort_keys=True
             ),
         },
     ]
@@ -420,19 +434,21 @@ def test_subscribe(subscribe_data):
         {
             "id": "047e27ad-2890-4372-b2cb-dfec57347eb9",
             "email": "mermista@example.com",
-            "return": pprint.PrettyPrinter().pformat(
-                {"message": "Successfully deleted 1 row(s)"}
+            "return": json.dumps(
+                {"message": "Successfully deleted 1 row(s)"},
+                indent=4, sort_keys=True
             ),
         },
         {
             "id": "98536487-06fe-4b1a-9e96-47d4f36bf819",
             "email": "castaspella@example.com",
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 {
                     "title": "No subscription found",
                     "status": 404,
                     "detail": "No subscription found for the specified parameters",
-                }
+                },
+                indent=4, sort_keys=True
             ),
         },
     ]

--- a/tests/unit/rest/test_tests.py
+++ b/tests/unit/rest/test_tests.py
@@ -26,7 +26,8 @@ def unstub():
                     "template_id": "3d1bfbab-d9ec-46c7-aa8e-9c1d1808f2b8",
                     "test_id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
                 },
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
         {
@@ -37,7 +38,8 @@ def unstub():
                     "status": 404,
                     "detail": "No test found with the specified ID",
                 },
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
     ]
@@ -88,7 +90,8 @@ def test_find_by_id(find_by_id_data):
                         "test_id": "bd132568-06fe-4b1a-9e96-47d4f36bf819",
                     }
                 ],
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
         {
@@ -113,7 +116,8 @@ def test_find_by_id(find_by_id_data):
                     "status": 404,
                     "detail": "No tests found with the specified parameters",
                 },
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
     ]
@@ -169,7 +173,8 @@ def test_find(find_data):
                     "template_id": "9d1bfbab-d9ec-46c7-aa8e-9c1d1808f2b8",
                     "test_id": "bd132568-06fe-4b1a-9e96-47d4f36bf819",
                 },
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
         {
@@ -187,7 +192,8 @@ def test_find(find_data):
                     "status": 500,
                     "detail": "Error while attempting to insert new test",
                 },
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
     ]
@@ -235,7 +241,8 @@ def test_create(create_data):
                     "template_id": "98536487-06fe-4b1a-9e96-47d4f36bf819",
                     "test_id": "bd132568-06fe-4b1a-9e96-47d4f36bf819",
                 },
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
         {
@@ -252,7 +259,8 @@ def test_create(create_data):
                     "status": 500,
                     "detail": "Error while attempting to update test",
                 },
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
     ]
@@ -283,8 +291,7 @@ def test_update(update_data):
         {
             "id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
             "return": json.dumps(
-                {"message": "Successfully deleted 1 row"},
-                indent=4, sort_keys=True
+                {"message": "Successfully deleted 1 row"}, indent=4, sort_keys=True
             ),
         },
         {
@@ -295,7 +302,8 @@ def test_update(update_data):
                     "status": 404,
                     "detail": "No test found with the specified ID",
                 },
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
     ]
@@ -338,7 +346,8 @@ def test_delete(delete_data):
                     "created_by": "micah@example.com",
                     "finished_at": None,
                 },
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
         {
@@ -355,7 +364,8 @@ def test_delete(delete_data):
                     "status": 500,
                     "detail": "Error while attempting to query the database: NotFound",
                 },
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
     ]
@@ -394,7 +404,8 @@ def test_run(run_data):
                     "email": "bow@example.com",
                     "created_at": "2020-09-23T19:41:46.839880",
                 },
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
         {
@@ -406,7 +417,8 @@ def test_run(run_data):
                     "status": 404,
                     "detail": "No test found with the specified ID",
                 },
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
     ]
@@ -435,8 +447,7 @@ def test_subscribe(subscribe_data):
             "id": "047e27ad-2890-4372-b2cb-dfec57347eb9",
             "email": "mermista@example.com",
             "return": json.dumps(
-                {"message": "Successfully deleted 1 row(s)"},
-                indent=4, sort_keys=True
+                {"message": "Successfully deleted 1 row(s)"}, indent=4, sort_keys=True
             ),
         },
         {
@@ -448,7 +459,8 @@ def test_subscribe(subscribe_data):
                     "status": 404,
                     "detail": "No subscription found for the specified parameters",
                 },
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
     ]

--- a/tests/unit/result/test_result_command.py
+++ b/tests/unit/result/test_result_command.py
@@ -1,4 +1,4 @@
-import pprint
+import json
 
 from click.testing import CliRunner
 
@@ -24,7 +24,7 @@ def no_email():
     params=[
         {
             "args": ["result", "find_by_id", "cd987859-06fe-4b1a-9e96-47d4f36bf819"],
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 {
                     "created_at": "2020-09-16T18:48:06.371563",
                     "created_by": "adora@example.com",
@@ -32,17 +32,19 @@ def no_email():
                     "description": "This result will save Etheria",
                     "name": "Sword of Protection result",
                     "result_id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
-                }
+                },
+                indent=4, sort_keys=True
             ),
         },
         {
             "args": ["result", "find_by_id", "cd987859-06fe-4b1a-9e96-47d4f36bf819"],
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 {
                     "title": "No result found",
                     "status": 404,
                     "detail": "No result found with the specified ID",
-                }
+                },
+                indent=4, sort_keys=True
             ),
         },
     ]
@@ -102,7 +104,7 @@ def test_find_by_id(find_by_id_data):
                 1,
                 0,
             ],
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 {
                     "created_at": "2020-09-16T18:48:06.371563",
                     "created_by": "adora@example.com",
@@ -110,7 +112,8 @@ def test_find_by_id(find_by_id_data):
                     "description": "This result will save Etheria",
                     "name": "Sword of Protection result",
                     "result_id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
-                }
+                },
+                indent=4, sort_keys=True
             ),
         },
         {
@@ -132,12 +135,13 @@ def test_find_by_id(find_by_id_data):
                 20,
                 0,
             ],
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 {
                     "title": "No results found",
                     "status": 404,
                     "detail": "No results found with the specified parameters",
-                }
+                },
+                indent=4, sort_keys=True
             ),
         },
     ]
@@ -188,7 +192,7 @@ def test_find(find_data):
                 "numeric",
                 "adora@example.com",
             ],
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 {
                     "created_at": "2020-09-16T18:48:06.371563",
                     "created_by": "adora@example.com",
@@ -196,7 +200,8 @@ def test_find(find_data):
                     "description": "This result will save Etheria",
                     "name": "Sword of Protection result",
                     "result_id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
-                }
+                },
+                indent=4, sort_keys=True
             ),
         },
         {
@@ -264,7 +269,7 @@ def test_create(create_data, caplog):
                 "New Sword of Protection result",
                 "This new result replaced the broken one",
             ],
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 {
                     "created_at": "2020-09-16T18:48:06.371563",
                     "created_by": "adora@example.com",
@@ -272,7 +277,8 @@ def test_create(create_data, caplog):
                     "description": "This new result replaced the broken one",
                     "name": "New Sword of Protection result",
                     "result_id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
-                }
+                },
+                indent=4, sort_keys=True
             ),
         },
         {
@@ -308,18 +314,20 @@ def test_update(update_data):
     params=[
         {
             "args": ["result", "delete", "cd987859-06fe-4b1a-9e96-47d4f36bf819"],
-            "return": pprint.PrettyPrinter().pformat(
-                {"message": "Successfully deleted 1 row"}
+            "return": json.dumps(
+                {"message": "Successfully deleted 1 row"},
+                indent=4, sort_keys=True
             ),
         },
         {
             "args": ["result", "delete", "cd987859-06fe-4b1a-9e96-47d4f36bf819"],
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 {
                     "title": "No result found",
                     "status": 404,
                     "detail": "No result found with the specified ID",
-                }
+                },
+                indent=4, sort_keys=True
             ),
         },
     ]
@@ -358,14 +366,15 @@ def test_delete(delete_data):
                 "out_horde_tanks",
                 "adora@example.com",
             ],
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 {
                     "template_id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
                     "result_id": "3d1bfbab-d9ec-46c7-aa8e-9c1d1808f2b8",
                     "result_key": "out_horde_tanks",
                     "created_at": "2020-09-24T19:07:59.311462",
                     "created_by": "rogelio@example.com",
-                }
+                },
+                indent=4, sort_keys=True
             ),
         },
         {

--- a/tests/unit/result/test_result_command.py
+++ b/tests/unit/result/test_result_command.py
@@ -33,7 +33,8 @@ def no_email():
                     "name": "Sword of Protection result",
                     "result_id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
                 },
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
         {
@@ -44,7 +45,8 @@ def no_email():
                     "status": 404,
                     "detail": "No result found with the specified ID",
                 },
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
     ]
@@ -113,7 +115,8 @@ def test_find_by_id(find_by_id_data):
                     "name": "Sword of Protection result",
                     "result_id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
                 },
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
         {
@@ -141,7 +144,8 @@ def test_find_by_id(find_by_id_data):
                     "status": 404,
                     "detail": "No results found with the specified parameters",
                 },
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
     ]
@@ -201,7 +205,8 @@ def test_find(find_data):
                     "name": "Sword of Protection result",
                     "result_id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
                 },
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
         {
@@ -278,7 +283,8 @@ def test_create(create_data, caplog):
                     "name": "New Sword of Protection result",
                     "result_id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
                 },
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
         {
@@ -315,8 +321,7 @@ def test_update(update_data):
         {
             "args": ["result", "delete", "cd987859-06fe-4b1a-9e96-47d4f36bf819"],
             "return": json.dumps(
-                {"message": "Successfully deleted 1 row"},
-                indent=4, sort_keys=True
+                {"message": "Successfully deleted 1 row"}, indent=4, sort_keys=True
             ),
         },
         {
@@ -327,7 +332,8 @@ def test_update(update_data):
                     "status": 404,
                     "detail": "No result found with the specified ID",
                 },
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
     ]
@@ -374,7 +380,8 @@ def test_delete(delete_data):
                     "created_at": "2020-09-24T19:07:59.311462",
                     "created_by": "rogelio@example.com",
                 },
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
         {

--- a/tests/unit/run/test_run_command.py
+++ b/tests/unit/run/test_run_command.py
@@ -1,4 +1,4 @@
-import pprint
+import json
 
 from click.testing import CliRunner
 
@@ -24,7 +24,7 @@ def no_email():
     params=[
         {
             "args": ["run", "find_by_id", "cd987859-06fe-4b1a-9e96-47d4f36bf819"],
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 {
                     "created_at": "2020-09-16T18:48:06.371563",
                     "finished_at": None,
@@ -38,17 +38,19 @@ def no_email():
                     "name": "Sword of Protection run",
                     "test_id": "3d1bfbab-d9ec-46c7-aa8e-9c1d1808f2b8",
                     "run_id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
-                }
+                },
+                indent=4, sort_keys=True
             ),
         },
         {
             "args": ["run", "find_by_id", "cd987859-06fe-4b1a-9e96-47d4f36bf819"],
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 {
                     "title": "No run found",
                     "status": 404,
                     "detail": "No run found with the specified ID",
-                }
+                },
+                indent=4, sort_keys=True
             ),
         },
     ]
@@ -73,18 +75,20 @@ def test_find_by_id(find_by_id_data):
     params=[
         {
             "args": ["run", "delete", "cd987859-06fe-4b1a-9e96-47d4f36bf819"],
-            "return": pprint.PrettyPrinter().pformat(
-                {"message": "Successfully deleted 1 row"}
+            "return": json.dumps(
+                {"message": "Successfully deleted 1 row"},
+                indent=4, sort_keys=True
             ),
         },
         {
             "args": ["run", "delete", "cd987859-06fe-4b1a-9e96-47d4f36bf819"],
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 {
                     "title": "No run found",
                     "status": 404,
                     "detail": "No run found with the specified ID",
-                }
+                },
+                indent=4, sort_keys=True
             ),
         },
     ]
@@ -123,7 +127,7 @@ def test_delete(delete_data):
                 "adora@example.com",
                 True,
             ],
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 {
                     "run_id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
                     "report_id": "3d1bfbab-d9ec-46c7-aa8e-9c1d1808f2b8",
@@ -133,7 +137,8 @@ def test_delete(delete_data):
                     "created_at": "2020-09-24T19:07:59.311462",
                     "created_by": "adora@example.com",
                     "finished_at": None,
-                }
+                },
+                indent=4, sort_keys=True
             ),
         },
         {
@@ -193,7 +198,7 @@ def test_create_report(create_report_data, caplog):
                 "cd987859-06fe-4b1a-9e96-47d4f36bf819",
                 "3d1bfbab-d9ec-46c7-aa8e-9c1d1808f2b8",
             ],
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 {
                     "run_id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
                     "report_id": "3d1bfbab-d9ec-46c7-aa8e-9c1d1808f2b8",
@@ -203,7 +208,8 @@ def test_create_report(create_report_data, caplog):
                     "created_at": "2020-09-24T19:07:59.311462",
                     "created_by": "rogelio@example.com",
                     "finished_at": "2020-09-24T21:07:59.311462",
-                }
+                },
+                indent=4, sort_keys=True
             ),
         },
         {
@@ -281,7 +287,7 @@ def test_find_report_by_ids(find_report_by_ids_data):
                 1,
                 0,
             ],
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 [
                     {
                         "run_id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
@@ -293,7 +299,8 @@ def test_find_report_by_ids(find_report_by_ids_data):
                         "created_by": "adora@example.com",
                         "finished_at": "2020-09-24T21:07:59.311462",
                     }
-                ]
+                ],
+                indent=4, sort_keys=True
             ),
         },
         {
@@ -317,12 +324,13 @@ def test_find_report_by_ids(find_report_by_ids_data):
                 20,
                 0,
             ],
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 {
                     "title": "No run_reports found",
                     "status": 404,
                     "detail": "No run_reports found with the specified parameters",
-                }
+                },
+                indent=4, sort_keys=True
             ),
         },
     ]
@@ -368,8 +376,9 @@ def test_find_reports(find_reports_data):
                 "cd987859-06fe-4b1a-9e96-47d4f36bf819",
                 "3d1bfbab-d9ec-46c7-aa8e-9c1d1808f2b8",
             ],
-            "return": pprint.PrettyPrinter().pformat(
-                {"message": "Successfully deleted 1 row"}
+            "return": json.dumps(
+                {"message": "Successfully deleted 1 row"},
+                indent=4, sort_keys=True
             ),
         },
         {

--- a/tests/unit/run/test_run_command.py
+++ b/tests/unit/run/test_run_command.py
@@ -39,7 +39,8 @@ def no_email():
                     "test_id": "3d1bfbab-d9ec-46c7-aa8e-9c1d1808f2b8",
                     "run_id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
                 },
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
         {
@@ -50,7 +51,8 @@ def no_email():
                     "status": 404,
                     "detail": "No run found with the specified ID",
                 },
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
     ]
@@ -76,8 +78,7 @@ def test_find_by_id(find_by_id_data):
         {
             "args": ["run", "delete", "cd987859-06fe-4b1a-9e96-47d4f36bf819"],
             "return": json.dumps(
-                {"message": "Successfully deleted 1 row"},
-                indent=4, sort_keys=True
+                {"message": "Successfully deleted 1 row"}, indent=4, sort_keys=True
             ),
         },
         {
@@ -88,7 +89,8 @@ def test_find_by_id(find_by_id_data):
                     "status": 404,
                     "detail": "No run found with the specified ID",
                 },
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
     ]
@@ -138,7 +140,8 @@ def test_delete(delete_data):
                     "created_by": "adora@example.com",
                     "finished_at": None,
                 },
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
         {
@@ -209,7 +212,8 @@ def test_create_report(create_report_data, caplog):
                     "created_by": "rogelio@example.com",
                     "finished_at": "2020-09-24T21:07:59.311462",
                 },
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
         {
@@ -300,7 +304,8 @@ def test_find_report_by_ids(find_report_by_ids_data):
                         "finished_at": "2020-09-24T21:07:59.311462",
                     }
                 ],
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
         {
@@ -330,7 +335,8 @@ def test_find_report_by_ids(find_report_by_ids_data):
                     "status": 404,
                     "detail": "No run_reports found with the specified parameters",
                 },
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
     ]
@@ -377,8 +383,7 @@ def test_find_reports(find_reports_data):
                 "3d1bfbab-d9ec-46c7-aa8e-9c1d1808f2b8",
             ],
             "return": json.dumps(
-                {"message": "Successfully deleted 1 row"},
-                indent=4, sort_keys=True
+                {"message": "Successfully deleted 1 row"}, indent=4, sort_keys=True
             ),
         },
         {

--- a/tests/unit/software/software_version/software_build/test_software_build_command.py
+++ b/tests/unit/software/software_version/software_build/test_software_build_command.py
@@ -1,4 +1,4 @@
-import pprint
+import json
 
 from click.testing import CliRunner
 
@@ -24,7 +24,7 @@ def unstub():
                 "find_by_id",
                 "cd987859-06fe-4b1a-9e96-47d4f36bf819",
             ],
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 {
                     "created_at": "2020-09-16T18:48:06.371563",
                     "status": "submitted",
@@ -33,7 +33,8 @@ def unstub():
                     "build_job_id": "d041bcce-288f-4c7e-9f9d-b6af57ae2369",
                     "software_version_id": "3d1bfbab-d9ec-46c7-aa8e-9c1d1808f2b8",
                     "software_build_id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
-                }
+                },
+                indent=4, sort_keys=True
             ),
         },
         {
@@ -44,12 +45,13 @@ def unstub():
                 "find_by_id",
                 "cd987859-06fe-4b1a-9e96-47d4f36bf819",
             ],
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 {
                     "title": "No software_build found",
                     "status": 404,
                     "detail": "No software_build found with the specified ID",
-                }
+                },
+                indent=4, sort_keys=True
             ),
         },
     ]
@@ -117,7 +119,7 @@ def test_find_by_id(find_by_id_data):
                 1,
                 0,
             ],
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 [
                     {
                         "created_at": "2020-09-16T18:48:06.371563",
@@ -128,7 +130,8 @@ def test_find_by_id(find_by_id_data):
                         "software_version_id": "3d1bfbab-d9ec-46c7-aa8e-9c1d1808f2b8",
                         "software_build_id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
                     }
-                ]
+                ],
+                indent=4, sort_keys=True
             ),
         },
         {
@@ -154,12 +157,13 @@ def test_find_by_id(find_by_id_data):
                 20,
                 0,
             ],
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 {
                     "title": "No software_builds found",
                     "status": 404,
                     "detail": "No software_builds found with the specified parameters",
-                }
+                },
+                indent=4, sort_keys=True
             ),
         },
     ]

--- a/tests/unit/software/software_version/software_build/test_software_build_command.py
+++ b/tests/unit/software/software_version/software_build/test_software_build_command.py
@@ -34,7 +34,8 @@ def unstub():
                     "software_version_id": "3d1bfbab-d9ec-46c7-aa8e-9c1d1808f2b8",
                     "software_build_id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
                 },
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
         {
@@ -51,7 +52,8 @@ def unstub():
                     "status": 404,
                     "detail": "No software_build found with the specified ID",
                 },
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
     ]
@@ -131,7 +133,8 @@ def test_find_by_id(find_by_id_data):
                         "software_build_id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
                     }
                 ],
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
         {
@@ -163,7 +166,8 @@ def test_find_by_id(find_by_id_data):
                     "status": 404,
                     "detail": "No software_builds found with the specified parameters",
                 },
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
     ]

--- a/tests/unit/software/software_version/test_software_version_command.py
+++ b/tests/unit/software/software_version/test_software_version_command.py
@@ -1,4 +1,4 @@
-import pprint
+import json
 
 from click.testing import CliRunner
 
@@ -23,13 +23,14 @@ def unstub():
                 "find_by_id",
                 "cd987859-06fe-4b1a-9e96-47d4f36bf819",
             ],
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 {
                     "created_at": "2020-09-16T18:48:06.371563",
                     "commit": "ca82a6dff817ec66f44342007202690a93763949",
                     "software_id": "3d1bfbab-d9ec-46c7-aa8e-9c1d1808f2b8",
                     "software_version_id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
-                }
+                },
+                indent=4, sort_keys=True
             ),
         },
         {
@@ -39,12 +40,13 @@ def unstub():
                 "find_by_id",
                 "cd987859-06fe-4b1a-9e96-47d4f36bf819",
             ],
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 {
                     "title": "No software_version found",
                     "status": 404,
                     "detail": "No software_version found with the specified ID",
-                }
+                },
+                indent=4, sort_keys=True
             ),
         },
     ]
@@ -102,7 +104,7 @@ def test_find_by_id(find_by_id_data):
                 1,
                 0,
             ],
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 [
                     {
                         "created_at": "2020-09-16T18:48:06.371563",
@@ -110,7 +112,8 @@ def test_find_by_id(find_by_id_data):
                         "software_id": "3d1bfbab-d9ec-46c7-aa8e-9c1d1808f2b8",
                         "software_version_id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
                     }
-                ]
+                ],
+                indent=4, sort_keys=True
             ),
         },
         {
@@ -132,12 +135,13 @@ def test_find_by_id(find_by_id_data):
                 20,
                 0,
             ],
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 {
                     "title": "No software_versions found",
                     "status": 404,
                     "detail": "No software_versions found with the specified parameters",
-                }
+                },
+                indent=4, sort_keys=True
             ),
         },
     ]

--- a/tests/unit/software/software_version/test_software_version_command.py
+++ b/tests/unit/software/software_version/test_software_version_command.py
@@ -30,7 +30,8 @@ def unstub():
                     "software_id": "3d1bfbab-d9ec-46c7-aa8e-9c1d1808f2b8",
                     "software_version_id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
                 },
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
         {
@@ -46,7 +47,8 @@ def unstub():
                     "status": 404,
                     "detail": "No software_version found with the specified ID",
                 },
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
     ]
@@ -113,7 +115,8 @@ def test_find_by_id(find_by_id_data):
                         "software_version_id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
                     }
                 ],
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
         {
@@ -141,7 +144,8 @@ def test_find_by_id(find_by_id_data):
                     "status": 404,
                     "detail": "No software_versions found with the specified parameters",
                 },
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
     ]

--- a/tests/unit/software/test_software_command.py
+++ b/tests/unit/software/test_software_command.py
@@ -1,4 +1,4 @@
-import pprint
+import json
 
 from click.testing import CliRunner
 
@@ -24,7 +24,7 @@ def no_email():
     params=[
         {
             "args": ["software", "find_by_id", "cd987859-06fe-4b1a-9e96-47d4f36bf819"],
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 {
                     "created_at": "2020-09-16T18:48:06.371563",
                     "created_by": "adora@example.com",
@@ -32,17 +32,19 @@ def no_email():
                     "description": "This software will save Etheria",
                     "name": "Sword of Protection software",
                     "software_id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
-                }
+                },
+                indent=4, sort_keys=True
             ),
         },
         {
             "args": ["software", "find_by_id", "cd987859-06fe-4b1a-9e96-47d4f36bf819"],
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 {
                     "title": "No software found",
                     "status": 404,
                     "detail": "No software found with the specified ID",
-                }
+                },
+                indent=4, sort_keys=True
             ),
         },
     ]
@@ -102,7 +104,7 @@ def test_find_by_id(find_by_id_data):
                 1,
                 0,
             ],
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 {
                     "created_at": "2020-09-16T18:48:06.371563",
                     "created_by": "adora@example.com",
@@ -110,7 +112,8 @@ def test_find_by_id(find_by_id_data):
                     "description": "This software will save Etheria",
                     "name": "Sword of Protection software",
                     "software_id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
-                }
+                },
+                indent=4, sort_keys=True
             ),
         },
         {
@@ -132,12 +135,13 @@ def test_find_by_id(find_by_id_data):
                 20,
                 0,
             ],
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 {
                     "title": "No software found",
                     "status": 404,
                     "detail": "No software found with the specified parameters",
-                }
+                },
+                indent=4, sort_keys=True
             ),
         },
     ]
@@ -188,7 +192,7 @@ def test_find(find_data):
                 "example.com/repo.git",
                 "adora@example.com",
             ],
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 {
                     "created_at": "2020-09-16T18:48:06.371563",
                     "created_by": "adora@example.com",
@@ -196,7 +200,8 @@ def test_find(find_data):
                     "description": "This software will save Etheria",
                     "name": "Sword of Protection software",
                     "software_id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
-                }
+                },
+                indent=4, sort_keys=True
             ),
         },
         {
@@ -264,7 +269,7 @@ def test_create(create_data, caplog):
                 "New Sword of Protection software",
                 "This new software replaced the broken one",
             ],
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 {
                     "created_at": "2020-09-16T18:48:06.371563",
                     "created_by": "adora@example.com",
@@ -272,7 +277,8 @@ def test_create(create_data, caplog):
                     "description": "This new software replaced the broken one",
                     "name": "New Sword of Protection software",
                     "software_id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
-                }
+                },
+                indent=4, sort_keys=True
             ),
         },
         {

--- a/tests/unit/software/test_software_command.py
+++ b/tests/unit/software/test_software_command.py
@@ -33,7 +33,8 @@ def no_email():
                     "name": "Sword of Protection software",
                     "software_id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
                 },
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
         {
@@ -44,7 +45,8 @@ def no_email():
                     "status": 404,
                     "detail": "No software found with the specified ID",
                 },
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
     ]
@@ -113,7 +115,8 @@ def test_find_by_id(find_by_id_data):
                     "name": "Sword of Protection software",
                     "software_id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
                 },
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
         {
@@ -141,7 +144,8 @@ def test_find_by_id(find_by_id_data):
                     "status": 404,
                     "detail": "No software found with the specified parameters",
                 },
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
     ]
@@ -201,7 +205,8 @@ def test_find(find_data):
                     "name": "Sword of Protection software",
                     "software_id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
                 },
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
         {
@@ -278,7 +283,8 @@ def test_create(create_data, caplog):
                     "name": "New Sword of Protection software",
                     "software_id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
                 },
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
         {

--- a/tests/unit/template/test_template_command.py
+++ b/tests/unit/template/test_template_command.py
@@ -35,7 +35,8 @@ def no_email():
                     "pipeline_id": "3d1bfbab-d9ec-46c7-aa8e-9c1d1808f2b8",
                     "template_id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
                 },
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
         {
@@ -46,7 +47,8 @@ def no_email():
                     "status": 404,
                     "detail": "No template found with the specified ID",
                 },
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
     ]
@@ -128,7 +130,8 @@ def test_find_by_id(find_by_id_data):
                         "template_id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
                     }
                 ],
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
         {
@@ -159,7 +162,8 @@ def test_find_by_id(find_by_id_data):
                     "status": 404,
                     "detail": "No templates found with the specified parameters",
                 },
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
     ]
@@ -230,7 +234,8 @@ def test_find(find_data):
                     "pipeline_id": "4d1bfbab-d9ec-46c7-aa8e-9c1d1808f2b8",
                     "template_id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
                 },
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
         {
@@ -321,7 +326,8 @@ def test_create(create_data, caplog):
                     "pipeline_id": "4d1bfbab-d9ec-46c7-aa8e-9c1d1808f2b8",
                     "template_id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
                 },
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
         {
@@ -360,8 +366,7 @@ def test_update(update_data):
         {
             "args": ["template", "delete", "cd987859-06fe-4b1a-9e96-47d4f36bf819"],
             "return": json.dumps(
-                {"message": "Successfully deleted 1 row"},
-                indent=4, sort_keys=True
+                {"message": "Successfully deleted 1 row"}, indent=4, sort_keys=True
             ),
         },
         {
@@ -372,7 +377,8 @@ def test_update(update_data):
                     "status": 404,
                     "detail": "No template found with the specified ID",
                 },
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
     ]
@@ -463,7 +469,8 @@ def test_delete(delete_data):
                         "run_id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
                     }
                 ],
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
         {
@@ -491,7 +498,8 @@ def test_delete(delete_data):
                     "status": 404,
                     "detail": "No runs found with the specified parameters",
                 },
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
         {
@@ -561,7 +569,8 @@ def test_find_runs(find_runs_data, caplog):
                     "email": "netossa@example.com",
                     "created_at": "2020-09-23T19:41:46.839880",
                 },
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
         {
@@ -582,7 +591,8 @@ def test_find_runs(find_runs_data, caplog):
                     "status": 404,
                     "detail": "No template found with the specified ID",
                 },
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
         {
@@ -596,7 +606,8 @@ def test_find_runs(find_runs_data, caplog):
                     "email": "frosta@example.com",
                     "created_at": "2020-09-23T19:41:46.839880",
                 },
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
     ]
@@ -630,8 +641,7 @@ def test_subscribe(subscribe_data):
             ],
             "params": ["cd987859-06fe-4b1a-9e96-47d4f36bf819", "netossa@example.com"],
             "return": json.dumps(
-                {"message": "Successfully deleted 1 row(s)"},
-                indent=4, sort_keys=True
+                {"message": "Successfully deleted 1 row(s)"}, indent=4, sort_keys=True
             ),
         },
         {
@@ -652,15 +662,15 @@ def test_subscribe(subscribe_data):
                     "status": 404,
                     "detail": "No subscription found for the specified parameters",
                 },
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
         {
             "args": ["template", "unsubscribe", "89657859-06fe-4b1a-9e96-47d4f36bf819"],
             "params": ["89657859-06fe-4b1a-9e96-47d4f36bf819", "frosta@example.com"],
             "return": json.dumps(
-                {"message": "Successfully deleted 1 row(s)"},
-                indent=4, sort_keys=True
+                {"message": "Successfully deleted 1 row(s)"}, indent=4, sort_keys=True
             ),
         },
     ]
@@ -708,7 +718,8 @@ def test_unsubscribe(unsubscribe_data):
                     "created_at": "2020-09-24T19:07:59.311462",
                     "created_by": "rogelio@example.com",
                 },
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
         {
@@ -777,7 +788,8 @@ def test_map_to_result(map_to_result_data, caplog):
                     "created_at": "2020-09-24T19:07:59.311462",
                     "created_by": "rogelio@example.com",
                 },
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
         {
@@ -853,7 +865,8 @@ def test_find_result_map_by_id(find_result_map_by_id_data):
                         "created_by": "adora@example.com",
                     }
                 ],
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
         {
@@ -879,7 +892,8 @@ def test_find_result_map_by_id(find_result_map_by_id_data):
                     "status": 404,
                     "detail": "No template_results found with the specified parameters",
                 },
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
     ]
@@ -922,8 +936,7 @@ def test_find_result_maps(find_result_maps_data):
                 "3d1bfbab-d9ec-46c7-aa8e-9c1d1808f2b8",
             ],
             "return": json.dumps(
-                {"message": "Successfully deleted 1 row"},
-                indent=4, sort_keys=True
+                {"message": "Successfully deleted 1 row"}, indent=4, sort_keys=True
             ),
         },
         {
@@ -977,7 +990,8 @@ def test_delete_result_map_by_id(delete_result_map_by_id_data):
                     "created_at": "2020-09-24T19:07:59.311462",
                     "created_by": "rogelio@example.com",
                 },
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
         {
@@ -1044,7 +1058,8 @@ def test_map_to_report(map_to_report_data, caplog):
                     "created_at": "2020-09-24T19:07:59.311462",
                     "created_by": "rogelio@example.com",
                 },
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
         {
@@ -1116,7 +1131,8 @@ def test_find_report_map_by_id(find_report_map_by_id_data):
                         "created_by": "adora@example.com",
                     }
                 ],
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
         {
@@ -1141,7 +1157,8 @@ def test_find_report_map_by_id(find_report_map_by_id_data):
                     "status": 404,
                     "detail": "No template_reports found with the specified parameters",
                 },
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
     ]
@@ -1183,8 +1200,7 @@ def test_find_report_maps(find_report_maps_data):
                 "3d1bfbab-d9ec-46c7-aa8e-9c1d1808f2b8",
             ],
             "return": json.dumps(
-                {"message": "Successfully deleted 1 row"},
-                indent=4, sort_keys=True
+                {"message": "Successfully deleted 1 row"}, indent=4, sort_keys=True
             ),
         },
         {

--- a/tests/unit/template/test_template_command.py
+++ b/tests/unit/template/test_template_command.py
@@ -1,4 +1,4 @@
-import pprint
+import json
 
 from click.testing import CliRunner
 
@@ -24,7 +24,7 @@ def no_email():
     params=[
         {
             "args": ["template", "find_by_id", "cd987859-06fe-4b1a-9e96-47d4f36bf819"],
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 {
                     "created_at": "2020-09-16T18:48:06.371563",
                     "created_by": "adora@example.com",
@@ -34,17 +34,19 @@ def no_email():
                     "name": "Sword of Protection template",
                     "pipeline_id": "3d1bfbab-d9ec-46c7-aa8e-9c1d1808f2b8",
                     "template_id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
-                }
+                },
+                indent=4, sort_keys=True
             ),
         },
         {
             "args": ["template", "find_by_id", "cd987859-06fe-4b1a-9e96-47d4f36bf819"],
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 {
                     "title": "No template found",
                     "status": 404,
                     "detail": "No template found with the specified ID",
-                }
+                },
+                indent=4, sort_keys=True
             ),
         },
     ]
@@ -113,7 +115,7 @@ def test_find_by_id(find_by_id_data):
                 1,
                 0,
             ],
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 [
                     {
                         "created_at": "2020-09-16T18:48:06.371563",
@@ -125,7 +127,8 @@ def test_find_by_id(find_by_id_data):
                         "pipeline_id": "4d1bfbab-d9ec-46c7-aa8e-9c1d1808f2b8",
                         "template_id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
                     }
-                ]
+                ],
+                indent=4, sort_keys=True
             ),
         },
         {
@@ -150,12 +153,13 @@ def test_find_by_id(find_by_id_data):
                 20,
                 0,
             ],
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 {
                     "title": "No templates found",
                     "status": 404,
                     "detail": "No templates found with the specified parameters",
-                }
+                },
+                indent=4, sort_keys=True
             ),
         },
     ]
@@ -215,7 +219,7 @@ def test_find(find_data):
                 "example.com/she-ra_eval.wdl",
                 "adora@example.com",
             ],
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 {
                     "created_at": "2020-09-16T18:48:06.371563",
                     "created_by": "adora@example.com",
@@ -225,7 +229,8 @@ def test_find(find_data):
                     "name": "Sword of Protection template",
                     "pipeline_id": "4d1bfbab-d9ec-46c7-aa8e-9c1d1808f2b8",
                     "template_id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
-                }
+                },
+                indent=4, sort_keys=True
             ),
         },
         {
@@ -305,7 +310,7 @@ def test_create(create_data, caplog):
                 "example.com/she-ra_test.wdl",
                 "example.com/she-ra_eval.wdl",
             ],
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 {
                     "created_at": "2020-09-16T18:48:06.371563",
                     "created_by": "adora@example.com",
@@ -315,7 +320,8 @@ def test_create(create_data, caplog):
                     "name": "New Sword of Protection template",
                     "pipeline_id": "4d1bfbab-d9ec-46c7-aa8e-9c1d1808f2b8",
                     "template_id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
-                }
+                },
+                indent=4, sort_keys=True
             ),
         },
         {
@@ -353,18 +359,20 @@ def test_update(update_data):
     params=[
         {
             "args": ["template", "delete", "cd987859-06fe-4b1a-9e96-47d4f36bf819"],
-            "return": pprint.PrettyPrinter().pformat(
-                {"message": "Successfully deleted 1 row"}
+            "return": json.dumps(
+                {"message": "Successfully deleted 1 row"},
+                indent=4, sort_keys=True
             ),
         },
         {
             "args": ["template", "delete", "cd987859-06fe-4b1a-9e96-47d4f36bf819"],
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 {
                     "title": "No template found",
                     "status": 404,
                     "detail": "No template found with the specified ID",
-                }
+                },
+                indent=4, sort_keys=True
             ),
         },
     ]
@@ -438,7 +446,7 @@ def test_delete(delete_data):
                 1,
                 0,
             ],
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 [
                     {
                         "created_at": "2020-09-16T18:48:06.371563",
@@ -454,7 +462,8 @@ def test_delete(delete_data):
                         "test_id": "3d1bfbab-d9ec-46c7-aa8e-9c1d1808f2b8",
                         "run_id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
                     }
-                ]
+                ],
+                indent=4, sort_keys=True
             ),
         },
         {
@@ -476,12 +485,13 @@ def test_delete(delete_data):
                 20,
                 0,
             ],
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 {
                     "title": "No run found",
                     "status": 404,
                     "detail": "No runs found with the specified parameters",
-                }
+                },
+                indent=4, sort_keys=True
             ),
         },
         {
@@ -543,14 +553,15 @@ def test_find_runs(find_runs_data, caplog):
                 "netossa@example.com",
             ],
             "params": ["cd987859-06fe-4b1a-9e96-47d4f36bf819", "netossa@example.com"],
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 {
                     "subscription_id": "361b3b95-4a6e-40d9-bd98-f92b2959864e",
                     "entity_type": "template",
                     "entity_id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
                     "email": "netossa@example.com",
                     "created_at": "2020-09-23T19:41:46.839880",
-                }
+                },
+                indent=4, sort_keys=True
             ),
         },
         {
@@ -565,25 +576,27 @@ def test_find_runs(find_runs_data, caplog):
                 "89657859-06fe-4b1a-9e96-47d4f36bf819",
                 "spinnerella@example.com",
             ],
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 {
                     "title": "No template found",
                     "status": 404,
                     "detail": "No template found with the specified ID",
-                }
+                },
+                indent=4, sort_keys=True
             ),
         },
         {
             "args": ["template", "subscribe", "89657859-06fe-4b1a-9e96-47d4f36bf819"],
             "params": ["89657859-06fe-4b1a-9e96-47d4f36bf819", "frosta@example.com"],
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 {
                     "subscription_id": "361b3b95-4a6e-40d9-bd98-f92b2959864e",
                     "entity_type": "template",
                     "entity_id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
                     "email": "frosta@example.com",
                     "created_at": "2020-09-23T19:41:46.839880",
-                }
+                },
+                indent=4, sort_keys=True
             ),
         },
     ]
@@ -616,8 +629,9 @@ def test_subscribe(subscribe_data):
                 "netossa@example.com",
             ],
             "params": ["cd987859-06fe-4b1a-9e96-47d4f36bf819", "netossa@example.com"],
-            "return": pprint.PrettyPrinter().pformat(
-                {"message": "Successfully deleted 1 row(s)"}
+            "return": json.dumps(
+                {"message": "Successfully deleted 1 row(s)"},
+                indent=4, sort_keys=True
             ),
         },
         {
@@ -632,19 +646,21 @@ def test_subscribe(subscribe_data):
                 "89657859-06fe-4b1a-9e96-47d4f36bf819",
                 "spinnerella@example.com",
             ],
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 {
                     "title": "No subscription found",
                     "status": 404,
                     "detail": "No subscription found for the specified parameters",
-                }
+                },
+                indent=4, sort_keys=True
             ),
         },
         {
             "args": ["template", "unsubscribe", "89657859-06fe-4b1a-9e96-47d4f36bf819"],
             "params": ["89657859-06fe-4b1a-9e96-47d4f36bf819", "frosta@example.com"],
-            "return": pprint.PrettyPrinter().pformat(
-                {"message": "Successfully deleted 1 row(s)"}
+            "return": json.dumps(
+                {"message": "Successfully deleted 1 row(s)"},
+                indent=4, sort_keys=True
             ),
         },
     ]
@@ -684,14 +700,15 @@ def test_unsubscribe(unsubscribe_data):
                 "out_horde_tanks",
                 "adora@example.com",
             ],
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 {
                     "template_id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
                     "result_id": "3d1bfbab-d9ec-46c7-aa8e-9c1d1808f2b8",
                     "result_key": "out_horde_tanks",
                     "created_at": "2020-09-24T19:07:59.311462",
                     "created_by": "rogelio@example.com",
-                }
+                },
+                indent=4, sort_keys=True
             ),
         },
         {
@@ -752,14 +769,15 @@ def test_map_to_result(map_to_result_data, caplog):
                 "cd987859-06fe-4b1a-9e96-47d4f36bf819",
                 "3d1bfbab-d9ec-46c7-aa8e-9c1d1808f2b8",
             ],
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 {
                     "template_id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
                     "result_id": "3d1bfbab-d9ec-46c7-aa8e-9c1d1808f2b8",
                     "result_key": "out_horde_tanks",
                     "created_at": "2020-09-24T19:07:59.311462",
                     "created_by": "rogelio@example.com",
-                }
+                },
+                indent=4, sort_keys=True
             ),
         },
         {
@@ -825,7 +843,7 @@ def test_find_result_map_by_id(find_result_map_by_id_data):
                 1,
                 0,
             ],
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 [
                     {
                         "template_id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
@@ -834,7 +852,8 @@ def test_find_result_map_by_id(find_result_map_by_id_data):
                         "created_at": "2020-09-24T19:07:59.311462",
                         "created_by": "adora@example.com",
                     }
-                ]
+                ],
+                indent=4, sort_keys=True
             ),
         },
         {
@@ -854,12 +873,13 @@ def test_find_result_map_by_id(find_result_map_by_id_data):
                 20,
                 0,
             ],
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 {
                     "title": "No template_results found",
                     "status": 404,
                     "detail": "No template_results found with the specified parameters",
-                }
+                },
+                indent=4, sort_keys=True
             ),
         },
     ]
@@ -901,8 +921,9 @@ def test_find_result_maps(find_result_maps_data):
                 "cd987859-06fe-4b1a-9e96-47d4f36bf819",
                 "3d1bfbab-d9ec-46c7-aa8e-9c1d1808f2b8",
             ],
-            "return": pprint.PrettyPrinter().pformat(
-                {"message": "Successfully deleted 1 row"}
+            "return": json.dumps(
+                {"message": "Successfully deleted 1 row"},
+                indent=4, sort_keys=True
             ),
         },
         {
@@ -949,13 +970,14 @@ def test_delete_result_map_by_id(delete_result_map_by_id_data):
                 "3d1bfbab-d9ec-46c7-aa8e-9c1d1808f2b8",
                 "adora@example.com",
             ],
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 {
                     "template_id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
                     "report_id": "3d1bfbab-d9ec-46c7-aa8e-9c1d1808f2b8",
                     "created_at": "2020-09-24T19:07:59.311462",
                     "created_by": "rogelio@example.com",
-                }
+                },
+                indent=4, sort_keys=True
             ),
         },
         {
@@ -1014,14 +1036,15 @@ def test_map_to_report(map_to_report_data, caplog):
                 "cd987859-06fe-4b1a-9e96-47d4f36bf819",
                 "3d1bfbab-d9ec-46c7-aa8e-9c1d1808f2b8",
             ],
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 {
                     "template_id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
                     "report_id": "3d1bfbab-d9ec-46c7-aa8e-9c1d1808f2b8",
                     "input_map": {"section1": {"input1": "val1"}},
                     "created_at": "2020-09-24T19:07:59.311462",
                     "created_by": "rogelio@example.com",
-                }
+                },
+                indent=4, sort_keys=True
             ),
         },
         {
@@ -1084,7 +1107,7 @@ def test_find_report_map_by_id(find_report_map_by_id_data):
                 1,
                 0,
             ],
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 [
                     {
                         "template_id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
@@ -1092,7 +1115,8 @@ def test_find_report_map_by_id(find_report_map_by_id_data):
                         "created_at": "2020-09-24T19:07:59.311462",
                         "created_by": "adora@example.com",
                     }
-                ]
+                ],
+                indent=4, sort_keys=True
             ),
         },
         {
@@ -1111,12 +1135,13 @@ def test_find_report_map_by_id(find_report_map_by_id_data):
                 20,
                 0,
             ],
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 {
                     "title": "No template_reports found",
                     "status": 404,
                     "detail": "No template_reports found with the specified parameters",
-                }
+                },
+                indent=4, sort_keys=True
             ),
         },
     ]
@@ -1157,8 +1182,9 @@ def test_find_report_maps(find_report_maps_data):
                 "cd987859-06fe-4b1a-9e96-47d4f36bf819",
                 "3d1bfbab-d9ec-46c7-aa8e-9c1d1808f2b8",
             ],
-            "return": pprint.PrettyPrinter().pformat(
-                {"message": "Successfully deleted 1 row"}
+            "return": json.dumps(
+                {"message": "Successfully deleted 1 row"},
+                indent=4, sort_keys=True
             ),
         },
         {

--- a/tests/unit/test/test_test_command.py
+++ b/tests/unit/test/test_test_command.py
@@ -35,7 +35,8 @@ def no_email():
                     "template_id": "3d1bfbab-d9ec-46c7-aa8e-9c1d1808f2b8",
                     "test_id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
                 },
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
         {
@@ -46,7 +47,8 @@ def no_email():
                     "status": 404,
                     "detail": "No test found with the specified ID",
                 },
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
     ]
@@ -130,7 +132,8 @@ def test_find_by_id(find_by_id_data):
                         "test_id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
                     }
                 ],
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
         {
@@ -161,7 +164,8 @@ def test_find_by_id(find_by_id_data):
                     "status": 404,
                     "detail": "No tests found with the specified parameters",
                 },
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
     ]
@@ -232,7 +236,8 @@ def test_find(find_data):
                     "template_id": "4d1bfbab-d9ec-46c7-aa8e-9c1d1808f2b8",
                     "test_id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
                 },
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
         {
@@ -323,7 +328,8 @@ def test_create(create_data, caplog):
                     "template_id": "4d1bfbab-d9ec-46c7-aa8e-9c1d1808f2b8",
                     "test_id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
                 },
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
         {
@@ -362,8 +368,7 @@ def test_update(update_data):
         {
             "args": ["run", "delete", "cd987859-06fe-4b1a-9e96-47d4f36bf819"],
             "return": json.dumps(
-                {"message": "Successfully deleted 1 row"},
-                indent=4, sort_keys=True
+                {"message": "Successfully deleted 1 row"}, indent=4, sort_keys=True
             ),
         },
         {
@@ -374,7 +379,8 @@ def test_update(update_data):
                     "status": 404,
                     "detail": "No run found with the specified ID",
                 },
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
     ]
@@ -434,7 +440,8 @@ def test_delete(delete_data):
                         "run_id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
                     }
                 ],
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
         {
@@ -458,7 +465,8 @@ def test_delete(delete_data):
                     "status": 500,
                     "title": "Server error",
                 },
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
         {
@@ -590,7 +598,8 @@ def test_run(run_data, caplog):
                         "run_id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
                     }
                 ],
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
         {
@@ -618,7 +627,8 @@ def test_run(run_data, caplog):
                     "status": 404,
                     "detail": "No runs found with the specified parameters",
                 },
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
         {
@@ -688,7 +698,8 @@ def test_find_runs(find_runs_data, caplog):
                     "email": "netossa@example.com",
                     "created_at": "2020-09-23T19:41:46.839880",
                 },
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
         {
@@ -709,7 +720,8 @@ def test_find_runs(find_runs_data, caplog):
                     "status": 404,
                     "detail": "No test found with the specified ID",
                 },
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
         {
@@ -723,7 +735,8 @@ def test_find_runs(find_runs_data, caplog):
                     "email": "frosta@example.com",
                     "created_at": "2020-09-23T19:41:46.839880",
                 },
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
     ]
@@ -757,8 +770,7 @@ def test_subscribe(subscribe_data):
             ],
             "params": ["cd987859-06fe-4b1a-9e96-47d4f36bf819", "netossa@example.com"],
             "return": json.dumps(
-                {"message": "Successfully deleted 1 row(s)"},
-                indent=4, sort_keys=True
+                {"message": "Successfully deleted 1 row(s)"}, indent=4, sort_keys=True
             ),
         },
         {
@@ -779,15 +791,15 @@ def test_subscribe(subscribe_data):
                     "status": 404,
                     "detail": "No subscription found for the specified parameters",
                 },
-                indent=4, sort_keys=True
+                indent=4,
+                sort_keys=True,
             ),
         },
         {
             "args": ["test", "unsubscribe", "89657859-06fe-4b1a-9e96-47d4f36bf819"],
             "params": ["89657859-06fe-4b1a-9e96-47d4f36bf819", "frosta@example.com"],
             "return": json.dumps(
-                {"message": "Successfully deleted 1 row(s)"},
-                indent=4, sort_keys=True
+                {"message": "Successfully deleted 1 row(s)"}, indent=4, sort_keys=True
             ),
         },
     ]

--- a/tests/unit/test/test_test_command.py
+++ b/tests/unit/test/test_test_command.py
@@ -1,4 +1,4 @@
-import pprint
+import json
 
 from click.testing import CliRunner
 
@@ -24,7 +24,7 @@ def no_email():
     params=[
         {
             "args": ["test", "find_by_id", "cd987859-06fe-4b1a-9e96-47d4f36bf819"],
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 {
                     "created_at": "2020-09-16T18:48:06.371563",
                     "created_by": "adora@example.com",
@@ -34,17 +34,19 @@ def no_email():
                     "name": "Sword of Protection test",
                     "template_id": "3d1bfbab-d9ec-46c7-aa8e-9c1d1808f2b8",
                     "test_id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
-                }
+                },
+                indent=4, sort_keys=True
             ),
         },
         {
             "args": ["test", "find_by_id", "cd987859-06fe-4b1a-9e96-47d4f36bf819"],
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 {
                     "title": "No test found",
                     "status": 404,
                     "detail": "No test found with the specified ID",
-                }
+                },
+                indent=4, sort_keys=True
             ),
         },
     ]
@@ -113,7 +115,7 @@ def test_find_by_id(find_by_id_data):
                 1,
                 0,
             ],
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 [
                     {
                         "created_at": "2020-09-16T18:48:06.371563",
@@ -127,7 +129,8 @@ def test_find_by_id(find_by_id_data):
                         "template_id": "4d1bfbab-d9ec-46c7-aa8e-9c1d1808f2b8",
                         "test_id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
                     }
-                ]
+                ],
+                indent=4, sort_keys=True
             ),
         },
         {
@@ -152,12 +155,13 @@ def test_find_by_id(find_by_id_data):
                 20,
                 0,
             ],
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 {
                     "title": "No tests found",
                     "status": 404,
                     "detail": "No tests found with the specified parameters",
-                }
+                },
+                indent=4, sort_keys=True
             ),
         },
     ]
@@ -217,7 +221,7 @@ def test_find(find_data):
                 {"in_output_filename": "test_greeting.txt"},
                 "adora@example.com",
             ],
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 {
                     "created_at": "2020-09-16T18:48:06.371563",
                     "created_by": "adora@example.com",
@@ -227,7 +231,8 @@ def test_find(find_data):
                     "name": "Sword of Protection test",
                     "template_id": "4d1bfbab-d9ec-46c7-aa8e-9c1d1808f2b8",
                     "test_id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
-                }
+                },
+                indent=4, sort_keys=True
             ),
         },
         {
@@ -307,7 +312,7 @@ def test_create(create_data, caplog):
                 {"in_greeted": "Cool Person"},
                 {"in_output_filename": "test_greeting.txt"},
             ],
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 {
                     "created_at": "2020-09-16T18:48:06.371563",
                     "created_by": "adora@example.com",
@@ -317,7 +322,8 @@ def test_create(create_data, caplog):
                     "name": "New Sword of Protection test",
                     "template_id": "4d1bfbab-d9ec-46c7-aa8e-9c1d1808f2b8",
                     "test_id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
-                }
+                },
+                indent=4, sort_keys=True
             ),
         },
         {
@@ -355,18 +361,20 @@ def test_update(update_data):
     params=[
         {
             "args": ["run", "delete", "cd987859-06fe-4b1a-9e96-47d4f36bf819"],
-            "return": pprint.PrettyPrinter().pformat(
-                {"message": "Successfully deleted 1 row"}
+            "return": json.dumps(
+                {"message": "Successfully deleted 1 row"},
+                indent=4, sort_keys=True
             ),
         },
         {
             "args": ["run", "delete", "cd987859-06fe-4b1a-9e96-47d4f36bf819"],
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 {
                     "title": "No run found",
                     "status": 404,
                     "detail": "No run found with the specified ID",
-                }
+                },
+                indent=4, sort_keys=True
             ),
         },
     ]
@@ -410,7 +418,7 @@ def test_delete(delete_data):
                 {"in_output_filename": "test_greeting.txt"},
                 "glimmer@example.com",
             ],
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 [
                     {
                         "created_at": "2020-09-16T18:48:06.371563",
@@ -425,7 +433,8 @@ def test_delete(delete_data):
                         "test_id": "3d1bfbab-d9ec-46c7-aa8e-9c1d1808f2b8",
                         "run_id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
                     }
-                ]
+                ],
+                indent=4, sort_keys=True
             ),
         },
         {
@@ -443,12 +452,13 @@ def test_delete(delete_data):
                 "",
                 "frosta@example.com",
             ],
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 {
                     "detail": "Error while attempting to query the database: NotFound",
                     "status": 500,
                     "title": "Server error",
-                }
+                },
+                indent=4, sort_keys=True
             ),
         },
         {
@@ -563,7 +573,7 @@ def test_run(run_data, caplog):
                 1,
                 0,
             ],
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 [
                     {
                         "created_at": "2020-09-16T18:48:06.371563",
@@ -579,7 +589,8 @@ def test_run(run_data, caplog):
                         "test_id": "3d1bfbab-d9ec-46c7-aa8e-9c1d1808f2b8",
                         "run_id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
                     }
-                ]
+                ],
+                indent=4, sort_keys=True
             ),
         },
         {
@@ -601,12 +612,13 @@ def test_run(run_data, caplog):
                 20,
                 0,
             ],
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 {
                     "title": "No run found",
                     "status": 404,
                     "detail": "No runs found with the specified parameters",
-                }
+                },
+                indent=4, sort_keys=True
             ),
         },
         {
@@ -668,14 +680,15 @@ def test_find_runs(find_runs_data, caplog):
                 "netossa@example.com",
             ],
             "params": ["cd987859-06fe-4b1a-9e96-47d4f36bf819", "netossa@example.com"],
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 {
                     "subscription_id": "361b3b95-4a6e-40d9-bd98-f92b2959864e",
                     "entity_type": "test",
                     "entity_id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
                     "email": "netossa@example.com",
                     "created_at": "2020-09-23T19:41:46.839880",
-                }
+                },
+                indent=4, sort_keys=True
             ),
         },
         {
@@ -690,25 +703,27 @@ def test_find_runs(find_runs_data, caplog):
                 "89657859-06fe-4b1a-9e96-47d4f36bf819",
                 "spinnerella@example.com",
             ],
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 {
                     "title": "No test found",
                     "status": 404,
                     "detail": "No test found with the specified ID",
-                }
+                },
+                indent=4, sort_keys=True
             ),
         },
         {
             "args": ["test", "subscribe", "89657859-06fe-4b1a-9e96-47d4f36bf819"],
             "params": ["89657859-06fe-4b1a-9e96-47d4f36bf819", "frosta@example.com"],
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 {
                     "subscription_id": "361b3b95-4a6e-40d9-bd98-f92b2959864e",
                     "entity_type": "test",
                     "entity_id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
                     "email": "frosta@example.com",
                     "created_at": "2020-09-23T19:41:46.839880",
-                }
+                },
+                indent=4, sort_keys=True
             ),
         },
     ]
@@ -741,8 +756,9 @@ def test_subscribe(subscribe_data):
                 "netossa@example.com",
             ],
             "params": ["cd987859-06fe-4b1a-9e96-47d4f36bf819", "netossa@example.com"],
-            "return": pprint.PrettyPrinter().pformat(
-                {"message": "Successfully deleted 1 row(s)"}
+            "return": json.dumps(
+                {"message": "Successfully deleted 1 row(s)"},
+                indent=4, sort_keys=True
             ),
         },
         {
@@ -757,19 +773,21 @@ def test_subscribe(subscribe_data):
                 "89657859-06fe-4b1a-9e96-47d4f36bf819",
                 "spinnerella@example.com",
             ],
-            "return": pprint.PrettyPrinter().pformat(
+            "return": json.dumps(
                 {
                     "title": "No subscription found",
                     "status": 404,
                     "detail": "No subscription found for the specified parameters",
-                }
+                },
+                indent=4, sort_keys=True
             ),
         },
         {
             "args": ["test", "unsubscribe", "89657859-06fe-4b1a-9e96-47d4f36bf819"],
             "params": ["89657859-06fe-4b1a-9e96-47d4f36bf819", "frosta@example.com"],
-            "return": pprint.PrettyPrinter().pformat(
-                {"message": "Successfully deleted 1 row(s)"}
+            "return": json.dumps(
+                {"message": "Successfully deleted 1 row(s)"},
+                indent=4, sort_keys=True
             ),
         },
     ]


### PR DESCRIPTION
Per #29 and broadinstitute/carrot#156, outputs from the CLI could be invalid json because of the way the output was formatted.  This change switches to using the json library for formatting to fix that.

Closes #29