### PR TITLE
Added confirmation for when user tries to delete something they did not create

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.3.2
+current_version = 0.3.3
 commit = True
 tag = False
 tag_name = {new_version}

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 # carrot\_cli
 Command Line Interface for CARROT
 
-Current version: 0.3.2
+Current version: 0.3.3
 
 ## Installation
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import find_packages, setup
 
 # following src dir layout according to
 # https://blog.ionelmc.ro/2014/05/25/python-packaging/#the-structure
-version = "0.3.2"
+version = "0.3.3"
 setup(
     name="carrot_cli",
     version=version,

--- a/src/carrot_cli/__main__.py
+++ b/src/carrot_cli/__main__.py
@@ -16,7 +16,7 @@ from .test import command as test
 
 # Version number is automatically set via bumpversion.
 # DO NOT MODIFY:
-__version__ = "0.3.2"
+__version__ = "0.3.3"
 
 # Create a logger for this module:
 LOGGER = logging.getLogger(__name__)

--- a/src/carrot_cli/command_util.py
+++ b/src/carrot_cli/command_util.py
@@ -1,0 +1,59 @@
+import json
+import logging
+import sys
+
+import click
+
+from .config import manager as config
+
+LOGGER = logging.getLogger(__name__)
+
+
+def delete(id, yes, entity, entity_name):
+    """
+    Calls entity's delete function with id
+    If yes is false, it first checks to see if the entity belongs to the user and prompts them to confirm the delete
+    if it does not.  Uses entity_name in the prompt
+    """
+    # Unless user specifies --yes flag, check first to see if the record exists and prompt to user to confirm delete if
+    # they are not the creator
+    if not yes:
+        # Try to find the record by id
+        record = json.loads(entity.find_by_id(id))
+        # If the returned record has a created_by field that does not match the user email, prompt the user to confirm
+        # the delete
+        user_email = config.load_var("email")
+        if "created_by" in record and record["created_by"] != user_email:
+            # If they decide not to delete, exit
+            if not click.confirm(
+                    f"{entity_name} with id {id} was created by {record['created_by']}. Are you sure you want to delete?"
+            ):
+                LOGGER.info("Okay, aborting delete operation")
+                sys.exit(0)
+
+    print(entity.delete(id))
+
+def delete_map(entity1_id, entity2_id, yes, map_entity, entity1_name, entity2_name):
+    """
+    Calls map_entity's delete map function with entity1_id and entity2_id
+    If yes is false, it first checks to see if the entity belongs to the user and prompts them to confirm the delete
+    if it does not.  Uses entity1_name and entity2_name in the prompt
+    """
+    # Unless user specifies --yes flag, check first to see if the record exists and prompt to user to confirm delete if
+    # they are not the creator
+    if not yes:
+        # Try to find the record by id
+        record = json.loads(map_entity.find_map_by_ids(entity1_id, entity2_id))
+        # If the returned record has a created_by field that does not match the user email, prompt the user to confirm
+        # the delete
+        user_email = config.load_var("email")
+        if "created_by" in record and record["created_by"] != user_email:
+            # If they decide not to delete, exit
+            if not click.confirm(
+                    f"Mapping for {entity1_name} with id {entity1_id} and {entity2_name} with id {entity2_id} was "
+                    f"created by {record['created_by']}. Are you sure you want to delete?"
+            ):
+                LOGGER.info("Okay, aborting delete operation")
+                sys.exit(0)
+
+    print(map_entity.delete_map_by_ids(entity1_id, entity2_id))

--- a/src/carrot_cli/config/manager.py
+++ b/src/carrot_cli/config/manager.py
@@ -7,6 +7,8 @@ LOGGER = logging.getLogger(__name__)
 
 CONFIG_VARIABLES = ["carrot_server_address", "email"]
 
+__CURRENT_CONFIG = {}
+
 
 def create_config_dir_if_not_exists():
     """Creates the .carrot_cli dir and config file if they don't exist"""

--- a/src/carrot_cli/pipeline/command.py
+++ b/src/carrot_cli/pipeline/command.py
@@ -4,6 +4,7 @@ import sys
 
 import click
 
+from .. import command_util
 from .. import file_util
 from ..config import manager as config
 from ..rest import pipelines, runs
@@ -136,23 +137,7 @@ def update(id, name, description):
 )
 def delete(id, yes):
     """Delete a pipeline by its ID, if the pipeline has no templates associated with it."""
-    # Unless user specifies --yes flag, check first to see if the record exists and prompt to user to confirm delete if
-    # they are not the creator
-    if not yes:
-        # Try to find the record by id
-        pipeline = json.loads(pipelines.find_by_id(id))
-        # If the returned pipeline has a created_by field that does not match the user email, prompt the user to confirm
-        # the delete
-        user_email = config.load_var("email")
-        if "created_by" in pipeline and pipeline["created_by"] != user_email:
-            # If they decide not to delete, exit
-            if not click.confirm(
-                f"Pipeline with id {id} was created by {pipeline['created_by']}. Are you sure you want to delete?"
-            ):
-                LOGGER.info("Okay, aborting delete operation")
-                sys.exit(0)
-
-    print(pipelines.delete(id))
+    command_util.delete(id, yes, pipelines, "Pipeline")
 
 
 @main.command(name="find_runs")

--- a/src/carrot_cli/report/command.py
+++ b/src/carrot_cli/report/command.py
@@ -4,6 +4,7 @@ import sys
 
 import click
 
+from .. import command_util
 from .. import file_util
 
 # Naming this differently here than in other files because reports have a config attribute
@@ -194,20 +195,4 @@ def update(id, name, description, notebook, config):
 )
 def delete(id, yes):
     """Delete a report by its ID, if the report has no templates, sections, or runs associated with it."""
-    # Unless user specifies --yes flag, check first to see if the record exists and prompt to user to confirm delete if
-    # they are not the creator
-    if not yes:
-        # Try to find the record by id
-        record = json.loads(reports.find_by_id(id))
-        # If the returned record has a created_by field that does not match the user email, prompt the user to confirm
-        # the delete
-        user_email = config_manager.load_var("email")
-        if "created_by" in record and record["created_by"] != user_email:
-            # If they decide not to delete, exit
-            if not click.confirm(
-                f"Report with id {id} was created by {record['created_by']}. Are you sure you want to delete?"
-            ):
-                LOGGER.info("Okay, aborting delete operation")
-                sys.exit(0)
-
-    print(reports.delete(id))
+    command_util.delete(id, yes, reports, "Report")

--- a/src/carrot_cli/rest/pipelines.py
+++ b/src/carrot_cli/rest/pipelines.py
@@ -1,5 +1,6 @@
 import logging
 
+from .. import config
 from . import request_handler
 
 LOGGER = logging.getLogger(__name__)

--- a/src/carrot_cli/result/command.py
+++ b/src/carrot_cli/result/command.py
@@ -1,3 +1,4 @@
+import json
 import logging
 import sys
 
@@ -134,8 +135,32 @@ def update(id, name, description):
 
 @main.command(name="delete")
 @click.argument("id")
-def find_by_id(id):
+@click.option(
+    "--yes",
+    "-y",
+    is_flag=True,
+    default=False,
+    help="Automatically answers yes if prompted to confirm delete of result created by "
+    "another user",
+)
+def delete(id, yes):
     """Delete a result definition by its ID, if the result is not mapped to any templates"""
+    # Unless user specifies --yes flag, check first to see if the record exists and prompt to user to confirm delete if
+    # they are not the creator
+    if not yes:
+        # Try to find the record by id
+        record = json.loads(results.find_by_id(id))
+        # If the returned record has a created_by field that does not match the user email, prompt the user to confirm
+        # the delete
+        user_email = config.load_var("email")
+        if "created_by" in record and record["created_by"] != user_email:
+            # If they decide not to delete, exit
+            if not click.confirm(
+                f"Result with id {id} was created by {record['created_by']}. Are you sure you want to delete?"
+            ):
+                LOGGER.info("Okay, aborting delete operation")
+                sys.exit(0)
+
     print(results.delete(id))
 
 

--- a/src/carrot_cli/result/command.py
+++ b/src/carrot_cli/result/command.py
@@ -4,6 +4,7 @@ import sys
 
 import click
 
+from .. import command_util
 from ..config import manager as config
 from ..rest import results, template_results
 
@@ -145,23 +146,7 @@ def update(id, name, description):
 )
 def delete(id, yes):
     """Delete a result definition by its ID, if the result is not mapped to any templates"""
-    # Unless user specifies --yes flag, check first to see if the record exists and prompt to user to confirm delete if
-    # they are not the creator
-    if not yes:
-        # Try to find the record by id
-        record = json.loads(results.find_by_id(id))
-        # If the returned record has a created_by field that does not match the user email, prompt the user to confirm
-        # the delete
-        user_email = config.load_var("email")
-        if "created_by" in record and record["created_by"] != user_email:
-            # If they decide not to delete, exit
-            if not click.confirm(
-                f"Result with id {id} was created by {record['created_by']}. Are you sure you want to delete?"
-            ):
-                LOGGER.info("Okay, aborting delete operation")
-                sys.exit(0)
-
-    print(results.delete(id))
+    command_util.delete(id, yes, results, "Result")
 
 
 @main.command(name="map_to_template")

--- a/src/carrot_cli/run/command.py
+++ b/src/carrot_cli/run/command.py
@@ -4,6 +4,7 @@ import sys
 
 import click
 
+from .. import command_util
 from .. import file_util
 from ..config import manager as config
 from ..rest import run_reports, runs
@@ -35,23 +36,7 @@ def find_by_id(id):
 )
 def delete(id, yes):
     """Delete a run by its ID, if the run has a failed status"""
-    # Unless user specifies --yes flag, check first to see if the record exists and prompt to user to confirm delete if
-    # they are not the creator
-    if not yes:
-        # Try to find the record by id
-        record = json.loads(runs.find_by_id(id))
-        # If the returned record has a created_by field that does not match the user email, prompt the user to confirm
-        # the delete
-        user_email = config.load_var("email")
-        if "created_by" in record and record["created_by"] != user_email:
-            # If they decide not to delete, exit
-            if not click.confirm(
-                f"Run with id {id} was created by {record['created_by']}. Are you sure you want to delete?"
-            ):
-                LOGGER.info("Okay, aborting delete operation")
-                sys.exit(0)
-
-    print(runs.delete(id))
+    command_util.delete(id, yes, runs, "Run")
 
 
 @main.command(name="create_report")
@@ -209,21 +194,4 @@ def delete_report_by_ids(id, report_id, yes):
     Delete the report record for the run specified by ID to the report specified by
     REPORT_ID
     """
-    # Unless user specifies --yes flag, check first to see if the record exists and prompt to user to confirm delete if
-    # they are not the creator
-    if not yes:
-        # Try to find the record by id
-        record = json.loads(run_reports.find_map_by_ids(id, report_id))
-        # If the returned record has a created_by field that does not match the user email, prompt the user to confirm
-        # the delete
-        user_email = config.load_var("email")
-        if "created_by" in record and record["created_by"] != user_email:
-            # If they decide not to delete, exit
-            if not click.confirm(
-                f"Run report for run with id {id} and report with id {report_id} was created by "
-                f"{record['created_by']}. Are you sure you want to delete?"
-            ):
-                LOGGER.info("Okay, aborting delete operation")
-                sys.exit(0)
-
-    print(run_reports.delete_map_by_ids(id, report_id))
+    command_util.delete_map(id, report_id, yes, run_reports, "run", "report")

--- a/src/carrot_cli/run/command.py
+++ b/src/carrot_cli/run/command.py
@@ -1,3 +1,4 @@
+import json
 import logging
 import sys
 
@@ -24,8 +25,32 @@ def find_by_id(id):
 
 @main.command(name="delete")
 @click.argument("id")
-def delete(id):
+@click.option(
+    "--yes",
+    "-y",
+    is_flag=True,
+    default=False,
+    help="Automatically answers yes if prompted to confirm delete of run created by "
+    "another user",
+)
+def delete(id, yes):
     """Delete a run by its ID, if the run has a failed status"""
+    # Unless user specifies --yes flag, check first to see if the record exists and prompt to user to confirm delete if
+    # they are not the creator
+    if not yes:
+        # Try to find the record by id
+        record = json.loads(runs.find_by_id(id))
+        # If the returned record has a created_by field that does not match the user email, prompt the user to confirm
+        # the delete
+        user_email = config.load_var("email")
+        if "created_by" in record and record["created_by"] != user_email:
+            # If they decide not to delete, exit
+            if not click.confirm(
+                f"Run with id {id} was created by {record['created_by']}. Are you sure you want to delete?"
+            ):
+                LOGGER.info("Okay, aborting delete operation")
+                sys.exit(0)
+
     print(runs.delete(id))
 
 
@@ -171,9 +196,34 @@ def find_reports(
 @main.command(name="delete_report_by_ids")
 @click.argument("id")
 @click.argument("report_id")
-def delete_report_by_ids(id, report_id):
+@click.option(
+    "--yes",
+    "-y",
+    is_flag=True,
+    default=False,
+    help="Automatically answers yes if prompted to confirm delete of report created by "
+    "another user",
+)
+def delete_report_by_ids(id, report_id, yes):
     """
     Delete the report record for the run specified by ID to the report specified by
     REPORT_ID
     """
+    # Unless user specifies --yes flag, check first to see if the record exists and prompt to user to confirm delete if
+    # they are not the creator
+    if not yes:
+        # Try to find the record by id
+        record = json.loads(run_reports.find_map_by_ids(id, report_id))
+        # If the returned record has a created_by field that does not match the user email, prompt the user to confirm
+        # the delete
+        user_email = config.load_var("email")
+        if "created_by" in record and record["created_by"] != user_email:
+            # If they decide not to delete, exit
+            if not click.confirm(
+                f"Run report for run with id {id} and report with id {report_id} was created by "
+                f"{record['created_by']}. Are you sure you want to delete?"
+            ):
+                LOGGER.info("Okay, aborting delete operation")
+                sys.exit(0)
+
     print(run_reports.delete_map_by_ids(id, report_id))

--- a/src/carrot_cli/template/command.py
+++ b/src/carrot_cli/template/command.py
@@ -4,6 +4,7 @@ import sys
 
 import click
 
+from .. import command_util
 from .. import file_util
 from ..config import manager as config
 from ..rest import runs, template_reports, template_results, templates
@@ -197,23 +198,7 @@ def update(id, name, description, test_wdl, eval_wdl):
 )
 def delete(id, yes):
     """Delete a template by its ID, if it has no tests associated with it"""
-    # Unless user specifies --yes flag, check first to see if the record exists and prompt to user to confirm delete if
-    # they are not the creator
-    if not yes:
-        # Try to find the record by id
-        record = json.loads(templates.find_by_id(id))
-        # If the returned record has a created_by field that does not match the user email, prompt the user to confirm
-        # the delete
-        user_email = config.load_var("email")
-        if "created_by" in record and record["created_by"] != user_email:
-            # If they decide not to delete, exit
-            if not click.confirm(
-                f"Template with id {id} was created by {record['created_by']}. Are you sure you want to delete?"
-            ):
-                LOGGER.info("Okay, aborting delete operation")
-                sys.exit(0)
-
-    print(templates.delete(id))
+    command_util.delete(id, yes, templates, "Template")
 
 
 @main.command(name="find_runs")
@@ -504,24 +489,7 @@ def delete_result_map_by_id(id, result_id, yes):
     RESULT_ID, if the specified template has no non-failed (i.e. successful or currently running)
     runs associated with it
     """
-    # Unless user specifies --yes flag, check first to see if the record exists and prompt to user to confirm delete if
-    # they are not the creator
-    if not yes:
-        # Try to find the record by id
-        record = json.loads(template_results.find_map_by_ids(id, result_id))
-        # If the returned record has a created_by field that does not match the user email, prompt the user to confirm
-        # the delete
-        user_email = config.load_var("email")
-        if "created_by" in record and record["created_by"] != user_email:
-            # If they decide not to delete, exit
-            if not click.confirm(
-                f"Template result mapping for template with id {id} and result with id {result_id} was created by "
-                f"{record['created_by']}. Are you sure you want to delete?"
-            ):
-                LOGGER.info("Okay, aborting delete operation")
-                sys.exit(0)
-
-    print(template_results.delete_map_by_ids(id, result_id))
+    command_util.delete_map(id, result_id, yes, template_results, "template", "result")
 
 
 @main.command(name="map_to_report")
@@ -638,21 +606,4 @@ def delete_report_map_by_id(id, report_id, yes):
     REPORT_ID, if the specified template has no non-failed (i.e. successful or currently running)
     runs associated with it
     """
-    # Unless user specifies --yes flag, check first to see if the record exists and prompt to user to confirm delete if
-    # they are not the creator
-    if not yes:
-        # Try to find the record by id
-        record = json.loads(template_reports.find_map_by_ids(id, report_id))
-        # If the returned record has a created_by field that does not match the user email, prompt the user to confirm
-        # the delete
-        user_email = config.load_var("email")
-        if "created_by" in record and record["created_by"] != user_email:
-            # If they decide not to delete, exit
-            if not click.confirm(
-                f"Template report mapping for template with id {id} and report with id {report_id} was created by "
-                f"{record['created_by']}. Are you sure you want to delete?"
-            ):
-                LOGGER.info("Okay, aborting delete operation")
-                sys.exit(0)
-
-    print(template_reports.delete_map_by_ids(id, report_id))
+    command_util.delete_map(id, report_id, yes, template_reports, "template", "report")

--- a/src/carrot_cli/test/command.py
+++ b/src/carrot_cli/test/command.py
@@ -1,3 +1,4 @@
+import json
 import logging
 import sys
 
@@ -201,8 +202,32 @@ def update(id, name, description, test_input_defaults, eval_input_defaults):
 
 @main.command(name="delete")
 @click.argument("id")
-def delete(id):
+@click.option(
+    "--yes",
+    "-y",
+    is_flag=True,
+    default=False,
+    help="Automatically answers yes if prompted to confirm delete of test created by "
+    "another user",
+)
+def delete(id, yes):
     """Delete a test by its ID, if the test has no runs associated with it"""
+    # Unless user specifies --yes flag, check first to see if the record exists and prompt to user to confirm delete if
+    # they are not the creator
+    if not yes:
+        # Try to find the record by id
+        record = json.loads(tests.find_by_id(id))
+        # If the returned record has a created_by field that does not match the user email, prompt the user to confirm
+        # the delete
+        user_email = config.load_var("email")
+        if "created_by" in record and record["created_by"] != user_email:
+            # If they decide not to delete, exit
+            if not click.confirm(
+                f"Test with id {id} was created by {record['created_by']}. Are you sure you want to delete?"
+            ):
+                LOGGER.info("Okay, aborting delete operation")
+                sys.exit(0)
+
     print(tests.delete(id))
 
 

--- a/src/carrot_cli/test/command.py
+++ b/src/carrot_cli/test/command.py
@@ -4,6 +4,7 @@ import sys
 
 import click
 
+from .. import command_util
 from .. import file_util
 from ..config import manager as config
 from ..rest import runs, tests
@@ -212,23 +213,7 @@ def update(id, name, description, test_input_defaults, eval_input_defaults):
 )
 def delete(id, yes):
     """Delete a test by its ID, if the test has no runs associated with it"""
-    # Unless user specifies --yes flag, check first to see if the record exists and prompt to user to confirm delete if
-    # they are not the creator
-    if not yes:
-        # Try to find the record by id
-        record = json.loads(tests.find_by_id(id))
-        # If the returned record has a created_by field that does not match the user email, prompt the user to confirm
-        # the delete
-        user_email = config.load_var("email")
-        if "created_by" in record and record["created_by"] != user_email:
-            # If they decide not to delete, exit
-            if not click.confirm(
-                f"Test with id {id} was created by {record['created_by']}. Are you sure you want to delete?"
-            ):
-                LOGGER.info("Okay, aborting delete operation")
-                sys.exit(0)
-
-    print(tests.delete(id))
+    command_util.delete(id, yes, tests, "Test")
 
 
 @main.command(name="run")

--- a/tests/unit/report/test_report_command.py
+++ b/tests/unit/report/test_report_command.py
@@ -1,4 +1,5 @@
 import json
+import logging
 
 from click.testing import CliRunner
 
@@ -714,12 +715,318 @@ def test_update(update_data):
     params=[
         {
             "args": ["report", "delete", "cd987859-06fe-4b1a-9e96-47d4f36bf819"],
+            "id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
+            "find_return": json.dumps(
+                {
+                    "config": {"cpu": 2},
+                    "created_at": "2020-09-16T18:48:06.371563",
+                    "created_by": "adora@example.com",
+                    "description": "This new report replaced the broken one",
+                    "name": "New Sword of Protection report",
+                    "notebook": {
+                        "metadata": {
+                            "language_info": {
+                                "codemirror_mode": {"name": "ipython", "version": 3},
+                                "file_extension": ".py",
+                                "mimetype": "text/x-python",
+                                "name": "python",
+                                "nbconvert_exporter": "python",
+                                "pygments_lexer": "ipython3",
+                                "version": "3.8.5-final",
+                            },
+                            "orig_nbformat": 2,
+                            "kernelspec": {
+                                "name": "python3",
+                                "display_name": "Python 3.8.5 64-bit",
+                                "metadata": {
+                                    "interpreter": {
+                                        "hash": "1ee38ef4a5a9feb55287fd749643f13d043cb0a7addaab2a9c224cbe137c0062"
+                                    }
+                                },
+                            },
+                        },
+                        "nbformat": 4,
+                        "nbformat_minor": 2,
+                        "cells": [
+                            {
+                                "cell_type": "code",
+                                "execution_count": None,
+                                "metadata": {},
+                                "outputs": [],
+                                "source": [
+                                    'message = carrot_run_data["results"]["Greeting"]\n',
+                                    "print(message)",
+                                ],
+                            },
+                            {
+                                "cell_type": "code",
+                                "execution_count": None,
+                                "metadata": {},
+                                "outputs": [],
+                                "source": [
+                                    'message_file = open(carrot_downloads["results"]["File Result"], \'r\')\n',
+                                    "print(message_file.read())",
+                                ],
+                            },
+                            {
+                                "cell_type": "code",
+                                "execution_count": None,
+                                "metadata": {},
+                                "outputs": [],
+                                "source": ["print('Thanks')"],
+                            },
+                        ],
+                    },
+                    "report_id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
+                }
+            ),
+            "email": "adora@example.com",
+            "return": json.dumps(
+                {"message": "Successfully deleted 1 row"}, indent=4, sort_keys=True
+            ),
+        },
+        {
+            "args": ["report", "delete", "-y", "cd987859-06fe-4b1a-9e96-47d4f36bf819"],
+            "id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
+            "find_return": json.dumps(
+                {
+                    "config": {"cpu": 2},
+                    "created_at": "2020-09-16T18:48:06.371563",
+                    "created_by": "adora@example.com",
+                    "description": "This new report replaced the broken one",
+                    "name": "New Sword of Protection report",
+                    "notebook": {
+                        "metadata": {
+                            "language_info": {
+                                "codemirror_mode": {"name": "ipython", "version": 3},
+                                "file_extension": ".py",
+                                "mimetype": "text/x-python",
+                                "name": "python",
+                                "nbconvert_exporter": "python",
+                                "pygments_lexer": "ipython3",
+                                "version": "3.8.5-final",
+                            },
+                            "orig_nbformat": 2,
+                            "kernelspec": {
+                                "name": "python3",
+                                "display_name": "Python 3.8.5 64-bit",
+                                "metadata": {
+                                    "interpreter": {
+                                        "hash": "1ee38ef4a5a9feb55287fd749643f13d043cb0a7addaab2a9c224cbe137c0062"
+                                    }
+                                },
+                            },
+                        },
+                        "nbformat": 4,
+                        "nbformat_minor": 2,
+                        "cells": [
+                            {
+                                "cell_type": "code",
+                                "execution_count": None,
+                                "metadata": {},
+                                "outputs": [],
+                                "source": [
+                                    'message = carrot_run_data["results"]["Greeting"]\n',
+                                    "print(message)",
+                                ],
+                            },
+                            {
+                                "cell_type": "code",
+                                "execution_count": None,
+                                "metadata": {},
+                                "outputs": [],
+                                "source": [
+                                    'message_file = open(carrot_downloads["results"]["File Result"], \'r\')\n',
+                                    "print(message_file.read())",
+                                ],
+                            },
+                            {
+                                "cell_type": "code",
+                                "execution_count": None,
+                                "metadata": {},
+                                "outputs": [],
+                                "source": ["print('Thanks')"],
+                            },
+                        ],
+                    },
+                    "report_id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
+                }
+            ),
+            "email": "catra@example.com",
             "return": json.dumps(
                 {"message": "Successfully deleted 1 row"}, indent=4, sort_keys=True
             ),
         },
         {
             "args": ["report", "delete", "cd987859-06fe-4b1a-9e96-47d4f36bf819"],
+            "id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
+            "find_return": json.dumps(
+                {
+                    "config": {"cpu": 2},
+                    "created_at": "2020-09-16T18:48:06.371563",
+                    "created_by": "adora@example.com",
+                    "description": "This new report replaced the broken one",
+                    "name": "New Sword of Protection report",
+                    "notebook": {
+                        "metadata": {
+                            "language_info": {
+                                "codemirror_mode": {"name": "ipython", "version": 3},
+                                "file_extension": ".py",
+                                "mimetype": "text/x-python",
+                                "name": "python",
+                                "nbconvert_exporter": "python",
+                                "pygments_lexer": "ipython3",
+                                "version": "3.8.5-final",
+                            },
+                            "orig_nbformat": 2,
+                            "kernelspec": {
+                                "name": "python3",
+                                "display_name": "Python 3.8.5 64-bit",
+                                "metadata": {
+                                    "interpreter": {
+                                        "hash": "1ee38ef4a5a9feb55287fd749643f13d043cb0a7addaab2a9c224cbe137c0062"
+                                    }
+                                },
+                            },
+                        },
+                        "nbformat": 4,
+                        "nbformat_minor": 2,
+                        "cells": [
+                            {
+                                "cell_type": "code",
+                                "execution_count": None,
+                                "metadata": {},
+                                "outputs": [],
+                                "source": [
+                                    'message = carrot_run_data["results"]["Greeting"]\n',
+                                    "print(message)",
+                                ],
+                            },
+                            {
+                                "cell_type": "code",
+                                "execution_count": None,
+                                "metadata": {},
+                                "outputs": [],
+                                "source": [
+                                    'message_file = open(carrot_downloads["results"]["File Result"], \'r\')\n',
+                                    "print(message_file.read())",
+                                ],
+                            },
+                            {
+                                "cell_type": "code",
+                                "execution_count": None,
+                                "metadata": {},
+                                "outputs": [],
+                                "source": ["print('Thanks')"],
+                            },
+                        ],
+                    },
+                    "report_id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
+                },
+                indent=4,
+                sort_keys=True,
+            ),
+            "email": "catra@example.com",
+            "return": json.dumps(
+                {"message": "Successfully deleted 1 row"}, indent=4, sort_keys=True
+            ),
+            "interactive": {
+                "input": "y",
+                "message": "Report with id cd987859-06fe-4b1a-9e96-47d4f36bf819 was created by adora@example.com. "
+                "Are you sure you want to delete? [y/N]: y\n",
+            },
+        },
+        {
+            "args": ["report", "delete", "cd987859-06fe-4b1a-9e96-47d4f36bf819"],
+            "id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
+            "find_return": json.dumps(
+                {
+                    "config": {"cpu": 2},
+                    "created_at": "2020-09-16T18:48:06.371563",
+                    "created_by": "adora@example.com",
+                    "description": "This new report replaced the broken one",
+                    "name": "New Sword of Protection report",
+                    "notebook": {
+                        "metadata": {
+                            "language_info": {
+                                "codemirror_mode": {"name": "ipython", "version": 3},
+                                "file_extension": ".py",
+                                "mimetype": "text/x-python",
+                                "name": "python",
+                                "nbconvert_exporter": "python",
+                                "pygments_lexer": "ipython3",
+                                "version": "3.8.5-final",
+                            },
+                            "orig_nbformat": 2,
+                            "kernelspec": {
+                                "name": "python3",
+                                "display_name": "Python 3.8.5 64-bit",
+                                "metadata": {
+                                    "interpreter": {
+                                        "hash": "1ee38ef4a5a9feb55287fd749643f13d043cb0a7addaab2a9c224cbe137c0062"
+                                    }
+                                },
+                            },
+                        },
+                        "nbformat": 4,
+                        "nbformat_minor": 2,
+                        "cells": [
+                            {
+                                "cell_type": "code",
+                                "execution_count": None,
+                                "metadata": {},
+                                "outputs": [],
+                                "source": [
+                                    'message = carrot_run_data["results"]["Greeting"]\n',
+                                    "print(message)",
+                                ],
+                            },
+                            {
+                                "cell_type": "code",
+                                "execution_count": None,
+                                "metadata": {},
+                                "outputs": [],
+                                "source": [
+                                    'message_file = open(carrot_downloads["results"]["File Result"], \'r\')\n',
+                                    "print(message_file.read())",
+                                ],
+                            },
+                            {
+                                "cell_type": "code",
+                                "execution_count": None,
+                                "metadata": {},
+                                "outputs": [],
+                                "source": ["print('Thanks')"],
+                            },
+                        ],
+                    },
+                    "report_id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
+                },
+                indent=4,
+                sort_keys=True,
+            ),
+            "email": "catra@example.com",
+            "return": "",
+            "interactive": {
+                "input": "n",
+                "message": "Report with id cd987859-06fe-4b1a-9e96-47d4f36bf819 was created by adora@example.com. "
+                "Are you sure you want to delete? [y/N]: n",
+            },
+            "logging": "Okay, aborting delete operation",
+        },
+        {
+            "args": ["report", "delete", "cd987859-06fe-4b1a-9e96-47d4f36bf819"],
+            "id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
+            "email": "catra@example.com",
+            "find_return": json.dumps(
+                {
+                    "title": "No report found",
+                    "status": 404,
+                    "detail": "No report found with the specified ID",
+                },
+                indent=4,
+                sort_keys=True,
+            ),
             "return": json.dumps(
                 {
                     "title": "No report found",
@@ -733,16 +1040,36 @@ def test_update(update_data):
     ]
 )
 def delete_data(request):
+    # We want to load the value from "email" from config
+    mockito.when(config).load_var("email").thenReturn(request.param["email"])
     # Set all requests to return None so only the one we expect will return a value
     mockito.when(reports).delete(...).thenReturn(None)
+    mockito.when(reports).find_by_id(...).thenReturn(None)
     # Mock up request response
-    mockito.when(reports).delete(request.param["args"][2]).thenReturn(
+    mockito.when(reports).delete(request.param["id"]).thenReturn(
         request.param["return"]
+    )
+    mockito.when(reports).find_by_id(request.param["id"]).thenReturn(
+        request.param["find_return"]
     )
     return request.param
 
 
-def test_delete(delete_data):
+def test_delete(delete_data, caplog):
+    caplog.set_level(logging.INFO)
     runner = CliRunner()
-    result = runner.invoke(carrot, delete_data["args"])
-    assert result.output == delete_data["return"] + "\n"
+    # Include interactive input and expected message if this test should trigger interactive stuff
+    if "interactive" in delete_data:
+        expected_output = (
+            delete_data["interactive"]["message"] + delete_data["return"] + "\n"
+        )
+        result = runner.invoke(
+            carrot, delete_data["args"], input=delete_data["interactive"]["input"]
+        )
+        assert result.output == expected_output
+    else:
+        result = runner.invoke(carrot, delete_data["args"])
+        assert result.output == delete_data["return"] + "\n"
+    # If we expect logging that we want to check, make sure it's there
+    if "logging" in delete_data:
+        assert delete_data["logging"] in caplog.text

--- a/tests/unit/run/test_run_command.py
+++ b/tests/unit/run/test_run_command.py
@@ -1,4 +1,5 @@
 import json
+import logging
 
 from click.testing import CliRunner
 
@@ -77,12 +78,130 @@ def test_find_by_id(find_by_id_data):
     params=[
         {
             "args": ["run", "delete", "cd987859-06fe-4b1a-9e96-47d4f36bf819"],
+            "id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
+            "find_return": json.dumps(
+                {
+                    "created_at": "2020-09-16T18:48:06.371563",
+                    "finished_at": "2020-09-16T18:58:06.371563",
+                    "created_by": "adora@example.com",
+                    "test_input": {"in_prev_owner": "Mara"},
+                    "eval_input": {"in_creators": "Old Ones"},
+                    "status": "evalfailed",
+                    "results": {},
+                    "test_cromwell_job_id": "d9855002-6b71-429c-a4de-8e90222488cd",
+                    "eval_cromwell_job_id": "39482203-6b71-429c-a4de-8e90222488cd",
+                    "name": "Sword of Protection run",
+                    "test_id": "3d1bfbab-d9ec-46c7-aa8e-9c1d1808f2b8",
+                    "run_id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
+                },
+                indent=4,
+                sort_keys=True,
+            ),
+            "email": "adora@example.com",
+            "return": json.dumps(
+                {"message": "Successfully deleted 1 row"}, indent=4, sort_keys=True
+            ),
+        },
+        {
+            "args": ["run", "delete", "-y", "cd987859-06fe-4b1a-9e96-47d4f36bf819"],
+            "id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
+            "find_return": json.dumps(
+                {
+                    "created_at": "2020-09-16T18:48:06.371563",
+                    "finished_at": "2020-09-16T18:58:06.371563",
+                    "created_by": "adora@example.com",
+                    "test_input": {"in_prev_owner": "Mara"},
+                    "eval_input": {"in_creators": "Old Ones"},
+                    "status": "evalfailed",
+                    "results": {},
+                    "test_cromwell_job_id": "d9855002-6b71-429c-a4de-8e90222488cd",
+                    "eval_cromwell_job_id": "39482203-6b71-429c-a4de-8e90222488cd",
+                    "name": "Sword of Protection run",
+                    "test_id": "3d1bfbab-d9ec-46c7-aa8e-9c1d1808f2b8",
+                    "run_id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
+                },
+                indent=4,
+                sort_keys=True,
+            ),
+            "email": "catra@example.com",
             "return": json.dumps(
                 {"message": "Successfully deleted 1 row"}, indent=4, sort_keys=True
             ),
         },
         {
             "args": ["run", "delete", "cd987859-06fe-4b1a-9e96-47d4f36bf819"],
+            "id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
+            "find_return": json.dumps(
+                {
+                    "created_at": "2020-09-16T18:48:06.371563",
+                    "finished_at": "2020-09-16T18:58:06.371563",
+                    "created_by": "adora@example.com",
+                    "test_input": {"in_prev_owner": "Mara"},
+                    "eval_input": {"in_creators": "Old Ones"},
+                    "status": "evalfailed",
+                    "results": {},
+                    "test_cromwell_job_id": "d9855002-6b71-429c-a4de-8e90222488cd",
+                    "eval_cromwell_job_id": "39482203-6b71-429c-a4de-8e90222488cd",
+                    "name": "Sword of Protection run",
+                    "test_id": "3d1bfbab-d9ec-46c7-aa8e-9c1d1808f2b8",
+                    "run_id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
+                },
+                indent=4,
+                sort_keys=True,
+            ),
+            "email": "catra@example.com",
+            "return": json.dumps(
+                {"message": "Successfully deleted 1 row"}, indent=4, sort_keys=True
+            ),
+            "interactive": {
+                "input": "y",
+                "message": "Run with id cd987859-06fe-4b1a-9e96-47d4f36bf819 was created by adora@example.com. "
+                "Are you sure you want to delete? [y/N]: y\n",
+            },
+        },
+        {
+            "args": ["run", "delete", "cd987859-06fe-4b1a-9e96-47d4f36bf819"],
+            "id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
+            "find_return": json.dumps(
+                {
+                    "created_at": "2020-09-16T18:48:06.371563",
+                    "finished_at": "2020-09-16T18:58:06.371563",
+                    "created_by": "adora@example.com",
+                    "test_input": {"in_prev_owner": "Mara"},
+                    "eval_input": {"in_creators": "Old Ones"},
+                    "status": "evalfailed",
+                    "results": {},
+                    "test_cromwell_job_id": "d9855002-6b71-429c-a4de-8e90222488cd",
+                    "eval_cromwell_job_id": "39482203-6b71-429c-a4de-8e90222488cd",
+                    "name": "Sword of Protection run",
+                    "test_id": "3d1bfbab-d9ec-46c7-aa8e-9c1d1808f2b8",
+                    "run_id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
+                },
+                indent=4,
+                sort_keys=True,
+            ),
+            "email": "catra@example.com",
+            "return": "",
+            "interactive": {
+                "input": "n",
+                "message": "Run with id cd987859-06fe-4b1a-9e96-47d4f36bf819 was created by adora@example.com. "
+                "Are you sure you want to delete? [y/N]: n",
+            },
+            "logging": "Okay, aborting delete operation",
+        },
+        {
+            "args": ["run", "delete", "cd987859-06fe-4b1a-9e96-47d4f36bf819"],
+            "id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
+            "find_return": json.dumps(
+                {
+                    "title": "No run found",
+                    "status": 404,
+                    "detail": "No run found with the specified ID",
+                },
+                indent=4,
+                sort_keys=True,
+            ),
+            "email": "adora@example.com",
             "return": json.dumps(
                 {
                     "title": "No run found",
@@ -96,19 +215,37 @@ def test_find_by_id(find_by_id_data):
     ]
 )
 def delete_data(request):
+    # We want to load the value from "email" from config
+    mockito.when(config).load_var("email").thenReturn(request.param["email"])
     # Set all requests to return None so only the one we expect will return a value
     mockito.when(runs).delete(...).thenReturn(None)
+    mockito.when(runs).find_by_id(...).thenReturn(None)
     # Mock up request response
-    mockito.when(runs).delete(request.param["args"][2]).thenReturn(
-        request.param["return"]
+    mockito.when(runs).delete(request.param["id"]).thenReturn(request.param["return"])
+    mockito.when(runs).find_by_id(request.param["id"]).thenReturn(
+        request.param["find_return"]
     )
     return request.param
 
 
-def test_delete(delete_data):
+def test_delete(delete_data, caplog):
+    caplog.set_level(logging.INFO)
     runner = CliRunner()
-    result = runner.invoke(carrot, delete_data["args"])
-    assert result.output == delete_data["return"] + "\n"
+    # Include interactive input and expected message if this test should trigger interactive stuff
+    if "interactive" in delete_data:
+        expected_output = (
+            delete_data["interactive"]["message"] + delete_data["return"] + "\n"
+        )
+        result = runner.invoke(
+            carrot, delete_data["args"], input=delete_data["interactive"]["input"]
+        )
+        assert result.output == expected_output
+    else:
+        result = runner.invoke(carrot, delete_data["args"])
+        assert result.output == delete_data["return"] + "\n"
+    # If we expect logging that we want to check, make sure it's there
+    if "logging" in delete_data:
+        assert delete_data["logging"] in caplog.text
 
 
 @pytest.fixture(
@@ -378,17 +515,149 @@ def test_find_reports(find_reports_data):
                 "cd987859-06fe-4b1a-9e96-47d4f36bf819",
                 "3d1bfbab-d9ec-46c7-aa8e-9c1d1808f2b8",
             ],
-            "params": [
+            "ids": [
                 "cd987859-06fe-4b1a-9e96-47d4f36bf819",
                 "3d1bfbab-d9ec-46c7-aa8e-9c1d1808f2b8",
             ],
+            "find_return": json.dumps(
+                {
+                    "run_id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
+                    "report_id": "3d1bfbab-d9ec-46c7-aa8e-9c1d1808f2b8",
+                    "status": "succeeded",
+                    "cromwell_job_id": "d9855002-6b71-429c-a4de-8e90222488cd",
+                    "results": {"result1": "val1"},
+                    "created_at": "2020-09-24T19:07:59.311462",
+                    "created_by": "adora@example.com",
+                    "finished_at": "2020-09-24T21:07:59.311462",
+                },
+                indent=4,
+                sort_keys=True,
+            ),
+            "email": "adora@example.com",
             "return": json.dumps(
                 {"message": "Successfully deleted 1 row"}, indent=4, sort_keys=True
             ),
         },
         {
+            "args": [
+                "run",
+                "delete_report_by_ids",
+                "-y",
+                "cd987859-06fe-4b1a-9e96-47d4f36bf819",
+                "3d1bfbab-d9ec-46c7-aa8e-9c1d1808f2b8",
+            ],
+            "ids": [
+                "cd987859-06fe-4b1a-9e96-47d4f36bf819",
+                "3d1bfbab-d9ec-46c7-aa8e-9c1d1808f2b8",
+            ],
+            "find_return": json.dumps(
+                {
+                    "run_id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
+                    "report_id": "3d1bfbab-d9ec-46c7-aa8e-9c1d1808f2b8",
+                    "status": "succeeded",
+                    "cromwell_job_id": "d9855002-6b71-429c-a4de-8e90222488cd",
+                    "results": {"result1": "val1"},
+                    "created_at": "2020-09-24T19:07:59.311462",
+                    "created_by": "adora@example.com",
+                    "finished_at": "2020-09-24T21:07:59.311462",
+                },
+                indent=4,
+                sort_keys=True,
+            ),
+            "email": "catra@example.com",
+            "return": json.dumps(
+                {"message": "Successfully deleted 1 row"}, indent=4, sort_keys=True
+            ),
+        },
+        {
+            "args": [
+                "run",
+                "delete_report_by_ids",
+                "cd987859-06fe-4b1a-9e96-47d4f36bf819",
+                "3d1bfbab-d9ec-46c7-aa8e-9c1d1808f2b8",
+            ],
+            "ids": [
+                "cd987859-06fe-4b1a-9e96-47d4f36bf819",
+                "3d1bfbab-d9ec-46c7-aa8e-9c1d1808f2b8",
+            ],
+            "find_return": json.dumps(
+                {
+                    "run_id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
+                    "report_id": "3d1bfbab-d9ec-46c7-aa8e-9c1d1808f2b8",
+                    "status": "succeeded",
+                    "cromwell_job_id": "d9855002-6b71-429c-a4de-8e90222488cd",
+                    "results": {"result1": "val1"},
+                    "created_at": "2020-09-24T19:07:59.311462",
+                    "created_by": "adora@example.com",
+                    "finished_at": "2020-09-24T21:07:59.311462",
+                },
+                indent=4,
+                sort_keys=True,
+            ),
+            "email": "catra@example.com",
+            "return": json.dumps(
+                {"message": "Successfully deleted 1 row"}, indent=4, sort_keys=True
+            ),
+            "interactive": {
+                "input": "y",
+                "message": "Run report for run with id cd987859-06fe-4b1a-9e96-47d4f36bf819 and report with id "
+                "3d1bfbab-d9ec-46c7-aa8e-9c1d1808f2b8 was created by adora@example.com. Are you sure you "
+                "want to delete? [y/N]: y\n",
+            },
+        },
+        {
+            "args": [
+                "run",
+                "delete_report_by_ids",
+                "cd987859-06fe-4b1a-9e96-47d4f36bf819",
+                "3d1bfbab-d9ec-46c7-aa8e-9c1d1808f2b8",
+            ],
+            "ids": [
+                "cd987859-06fe-4b1a-9e96-47d4f36bf819",
+                "3d1bfbab-d9ec-46c7-aa8e-9c1d1808f2b8",
+            ],
+            "find_return": json.dumps(
+                {
+                    "run_id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
+                    "report_id": "3d1bfbab-d9ec-46c7-aa8e-9c1d1808f2b8",
+                    "status": "succeeded",
+                    "cromwell_job_id": "d9855002-6b71-429c-a4de-8e90222488cd",
+                    "results": {"result1": "val1"},
+                    "created_at": "2020-09-24T19:07:59.311462",
+                    "created_by": "adora@example.com",
+                    "finished_at": "2020-09-24T21:07:59.311462",
+                },
+                indent=4,
+                sort_keys=True,
+            ),
+            "email": "catra@example.com",
+            "return": "",
+            "interactive": {
+                "input": "n",
+                "message": "Run report for run with id cd987859-06fe-4b1a-9e96-47d4f36bf819 and report with id "
+                "3d1bfbab-d9ec-46c7-aa8e-9c1d1808f2b8 was created by adora@example.com. Are you sure you "
+                "want to delete? [y/N]: n",
+            },
+            "logging": "Okay, aborting delete operation",
+        },
+        {
             "args": ["run", "delete_report_by_ids"],
-            "params": [],
+            "ids": [],
+            "find_return": json.dumps(
+                {
+                    "run_id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
+                    "report_id": "3d1bfbab-d9ec-46c7-aa8e-9c1d1808f2b8",
+                    "status": "succeeded",
+                    "cromwell_job_id": "d9855002-6b71-429c-a4de-8e90222488cd",
+                    "results": {"result1": "val1"},
+                    "created_at": "2020-09-24T19:07:59.311462",
+                    "created_by": "adora@example.com",
+                    "finished_at": "2020-09-24T21:07:59.311462",
+                },
+                indent=4,
+                sort_keys=True,
+            ),
+            "email": "adora@example.com",
             "return": "Usage: carrot_cli run delete_report_by_ids [OPTIONS] ID REPORT_ID\n"
             "Try 'carrot_cli run delete_report_by_ids --help' for help.\n"
             "\n"
@@ -397,18 +666,43 @@ def test_find_reports(find_reports_data):
     ]
 )
 def delete_report_by_ids_data(request):
+    # We want to load the value from "email" from config
+    mockito.when(config).load_var("email").thenReturn(request.param["email"])
     # Set all requests to return None so only the one we expect will return a value
     mockito.when(run_reports).delete_map_by_ids(...).thenReturn(None)
+    mockito.when(run_reports).find_map_by_ids(...).thenReturn(None)
     # Mock up request response only if we expect it to get that far
-    if len(request.param["params"]) > 0:
+    if len(request.param["ids"]) > 0:
         mockito.when(run_reports).delete_map_by_ids(
-            request.param["params"][0],
-            request.param["params"][1],
+            request.param["ids"][0],
+            request.param["ids"][1],
         ).thenReturn(request.param["return"])
+        mockito.when(run_reports).find_map_by_ids(
+            request.param["ids"][0],
+            request.param["ids"][1],
+        ).thenReturn(request.param["find_return"])
     return request.param
 
 
-def test_delete_report_by_ids(delete_report_by_ids_data):
+def test_delete_report_by_ids(delete_report_by_ids_data, caplog):
+    caplog.set_level(logging.INFO)
     runner = CliRunner()
-    result = runner.invoke(carrot, delete_report_by_ids_data["args"])
-    assert result.output == delete_report_by_ids_data["return"] + "\n"
+    # Include interactive input and expected message if this test should trigger interactive stuff
+    if "interactive" in delete_report_by_ids_data:
+        expected_output = (
+            delete_report_by_ids_data["interactive"]["message"]
+            + delete_report_by_ids_data["return"]
+            + "\n"
+        )
+        result = runner.invoke(
+            carrot,
+            delete_report_by_ids_data["args"],
+            input=delete_report_by_ids_data["interactive"]["input"],
+        )
+        assert result.output == expected_output
+    else:
+        result = runner.invoke(carrot, delete_report_by_ids_data["args"])
+        assert result.output == delete_report_by_ids_data["return"] + "\n"
+    # If we expect logging that we want to check, make sure it's there
+    if "logging" in delete_report_by_ids_data:
+        assert delete_report_by_ids_data["logging"] in caplog.text

--- a/tests/unit/run/test_run_command.py
+++ b/tests/unit/run/test_run_command.py
@@ -600,7 +600,7 @@ def test_find_reports(find_reports_data):
             ),
             "interactive": {
                 "input": "y",
-                "message": "Run report for run with id cd987859-06fe-4b1a-9e96-47d4f36bf819 and report with id "
+                "message": "Mapping for run with id cd987859-06fe-4b1a-9e96-47d4f36bf819 and report with id "
                 "3d1bfbab-d9ec-46c7-aa8e-9c1d1808f2b8 was created by adora@example.com. Are you sure you "
                 "want to delete? [y/N]: y\n",
             },
@@ -634,7 +634,7 @@ def test_find_reports(find_reports_data):
             "return": "",
             "interactive": {
                 "input": "n",
-                "message": "Run report for run with id cd987859-06fe-4b1a-9e96-47d4f36bf819 and report with id "
+                "message": "Mapping for run with id cd987859-06fe-4b1a-9e96-47d4f36bf819 and report with id "
                 "3d1bfbab-d9ec-46c7-aa8e-9c1d1808f2b8 was created by adora@example.com. Are you sure you "
                 "want to delete? [y/N]: n",
             },

--- a/tests/unit/template/test_template_command.py
+++ b/tests/unit/template/test_template_command.py
@@ -1135,7 +1135,7 @@ def test_find_result_maps(find_result_maps_data):
             ),
             "interactive": {
                 "input": "y",
-                "message": "Template result mapping for template with id cd987859-06fe-4b1a-9e96-47d4f36bf819 and "
+                "message": "Mapping for template with id cd987859-06fe-4b1a-9e96-47d4f36bf819 and "
                 "result with id 3d1bfbab-d9ec-46c7-aa8e-9c1d1808f2b8 was created by adora@example.com. Are "
                 "you sure you want to delete? [y/N]: y\n",
             },
@@ -1166,7 +1166,7 @@ def test_find_result_maps(find_result_maps_data):
             "return": "",
             "interactive": {
                 "input": "n",
-                "message": "Template result mapping for template with id cd987859-06fe-4b1a-9e96-47d4f36bf819 and "
+                "message": "Mapping for template with id cd987859-06fe-4b1a-9e96-47d4f36bf819 and "
                 "result with id 3d1bfbab-d9ec-46c7-aa8e-9c1d1808f2b8 was created by adora@example.com. Are "
                 "you sure you want to delete? [y/N]: n",
             },
@@ -1561,7 +1561,7 @@ def test_find_report_maps(find_report_maps_data):
             ),
             "interactive": {
                 "input": "y",
-                "message": "Template report mapping for template with id cd987859-06fe-4b1a-9e96-47d4f36bf819 and "
+                "message": "Mapping for template with id cd987859-06fe-4b1a-9e96-47d4f36bf819 and "
                 "report with id 3d1bfbab-d9ec-46c7-aa8e-9c1d1808f2b8 was created by adora@example.com. Are "
                 "you sure you want to delete? [y/N]: y\n",
             },
@@ -1592,7 +1592,7 @@ def test_find_report_maps(find_report_maps_data):
             "return": "",
             "interactive": {
                 "input": "n",
-                "message": "Template report mapping for template with id cd987859-06fe-4b1a-9e96-47d4f36bf819 and "
+                "message": "Mapping for template with id cd987859-06fe-4b1a-9e96-47d4f36bf819 and "
                 "report with id 3d1bfbab-d9ec-46c7-aa8e-9c1d1808f2b8 was created by adora@example.com. Are "
                 "you sure you want to delete? [y/N]: n",
             },

--- a/tests/unit/template/test_template_command.py
+++ b/tests/unit/template/test_template_command.py
@@ -1,4 +1,5 @@
 import json
+import logging
 
 from click.testing import CliRunner
 
@@ -365,12 +366,119 @@ def test_update(update_data):
     params=[
         {
             "args": ["template", "delete", "cd987859-06fe-4b1a-9e96-47d4f36bf819"],
+            "id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
+            "find_return": json.dumps(
+                {
+                    "created_at": "2020-09-16T18:48:06.371563",
+                    "created_by": "adora@example.com",
+                    "description": "This template replaced the broken one",
+                    "test_wdl": "example.com/she-ra_test.wdl",
+                    "eval_wdl": "example.com/she-ra_eval.wdl",
+                    "name": "New Sword of Protection template",
+                    "pipeline_id": "4d1bfbab-d9ec-46c7-aa8e-9c1d1808f2b8",
+                    "template_id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
+                },
+                indent=4,
+                sort_keys=True,
+            ),
+            "email": "adora@example.com",
+            "return": json.dumps(
+                {"message": "Successfully deleted 1 row"}, indent=4, sort_keys=True
+            ),
+        },
+        {
+            "args": [
+                "template",
+                "delete",
+                "-y",
+                "cd987859-06fe-4b1a-9e96-47d4f36bf819",
+            ],
+            "id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
+            "find_return": json.dumps(
+                {
+                    "created_at": "2020-09-16T18:48:06.371563",
+                    "created_by": "adora@example.com",
+                    "description": "This template replaced the broken one",
+                    "test_wdl": "example.com/she-ra_test.wdl",
+                    "eval_wdl": "example.com/she-ra_eval.wdl",
+                    "name": "New Sword of Protection template",
+                    "pipeline_id": "4d1bfbab-d9ec-46c7-aa8e-9c1d1808f2b8",
+                    "template_id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
+                },
+                indent=4,
+                sort_keys=True,
+            ),
+            "email": "catra@example.com",
             "return": json.dumps(
                 {"message": "Successfully deleted 1 row"}, indent=4, sort_keys=True
             ),
         },
         {
             "args": ["template", "delete", "cd987859-06fe-4b1a-9e96-47d4f36bf819"],
+            "id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
+            "find_return": json.dumps(
+                {
+                    "created_at": "2020-09-16T18:48:06.371563",
+                    "created_by": "adora@example.com",
+                    "description": "This template replaced the broken one",
+                    "test_wdl": "example.com/she-ra_test.wdl",
+                    "eval_wdl": "example.com/she-ra_eval.wdl",
+                    "name": "New Sword of Protection template",
+                    "pipeline_id": "4d1bfbab-d9ec-46c7-aa8e-9c1d1808f2b8",
+                    "template_id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
+                },
+                indent=4,
+                sort_keys=True,
+            ),
+            "email": "catra@example.com",
+            "return": json.dumps(
+                {"message": "Successfully deleted 1 row"}, indent=4, sort_keys=True
+            ),
+            "interactive": {
+                "input": "y",
+                "message": "Template with id cd987859-06fe-4b1a-9e96-47d4f36bf819 was created by adora@example.com. "
+                "Are you sure you want to delete? [y/N]: y\n",
+            },
+        },
+        {
+            "args": ["template", "delete", "cd987859-06fe-4b1a-9e96-47d4f36bf819"],
+            "id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
+            "find_return": json.dumps(
+                {
+                    "created_at": "2020-09-16T18:48:06.371563",
+                    "created_by": "adora@example.com",
+                    "description": "This template replaced the broken one",
+                    "test_wdl": "example.com/she-ra_test.wdl",
+                    "eval_wdl": "example.com/she-ra_eval.wdl",
+                    "name": "New Sword of Protection template",
+                    "pipeline_id": "4d1bfbab-d9ec-46c7-aa8e-9c1d1808f2b8",
+                    "template_id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
+                },
+                indent=4,
+                sort_keys=True,
+            ),
+            "email": "catra@example.com",
+            "return": "",
+            "interactive": {
+                "input": "n",
+                "message": "Template with id cd987859-06fe-4b1a-9e96-47d4f36bf819 was created by adora@example.com. "
+                "Are you sure you want to delete? [y/N]: n",
+            },
+            "logging": "Okay, aborting delete operation",
+        },
+        {
+            "args": ["template", "delete", "cd987859-06fe-4b1a-9e96-47d4f36bf819"],
+            "id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
+            "find_return": json.dumps(
+                {
+                    "title": "No template found",
+                    "status": 404,
+                    "detail": "No template found with the specified ID",
+                },
+                indent=4,
+                sort_keys=True,
+            ),
+            "email": "adora@example.com",
             "return": json.dumps(
                 {
                     "title": "No template found",
@@ -384,19 +492,39 @@ def test_update(update_data):
     ]
 )
 def delete_data(request):
+    # We want to load the value from "email" from config
+    mockito.when(config).load_var("email").thenReturn(request.param["email"])
     # Set all requests to return None so only the one we expect will return a value
     mockito.when(templates).delete(...).thenReturn(None)
+    mockito.when(templates).find_by_id(...).thenReturn(None)
     # Mock up request response
-    mockito.when(templates).delete(request.param["args"][2]).thenReturn(
+    mockito.when(templates).delete(request.param["id"]).thenReturn(
         request.param["return"]
+    )
+    mockito.when(templates).find_by_id(request.param["id"]).thenReturn(
+        request.param["find_return"]
     )
     return request.param
 
 
-def test_delete(delete_data):
+def test_delete(delete_data, caplog):
+    caplog.set_level(logging.INFO)
     runner = CliRunner()
-    result = runner.invoke(carrot, delete_data["args"])
-    assert result.output == delete_data["return"] + "\n"
+    # Include interactive input and expected message if this test should trigger interactive stuff
+    if "interactive" in delete_data:
+        expected_output = (
+            delete_data["interactive"]["message"] + delete_data["return"] + "\n"
+        )
+        result = runner.invoke(
+            carrot, delete_data["args"], input=delete_data["interactive"]["input"]
+        )
+        assert result.output == expected_output
+    else:
+        result = runner.invoke(carrot, delete_data["args"])
+        assert result.output == delete_data["return"] + "\n"
+    # If we expect logging that we want to check, make sure it's there
+    if "logging" in delete_data:
+        assert delete_data["logging"] in caplog.text
 
 
 @pytest.fixture(
@@ -931,17 +1059,154 @@ def test_find_result_maps(find_result_maps_data):
                 "cd987859-06fe-4b1a-9e96-47d4f36bf819",
                 "3d1bfbab-d9ec-46c7-aa8e-9c1d1808f2b8",
             ],
-            "params": [
+            "ids": [
                 "cd987859-06fe-4b1a-9e96-47d4f36bf819",
                 "3d1bfbab-d9ec-46c7-aa8e-9c1d1808f2b8",
             ],
+            "find_return": json.dumps(
+                {
+                    "template_id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
+                    "result_id": "4d1bfbab-d9ec-46c7-aa8e-9c1d1808f2b8",
+                    "result_key": "sword_of_protection_key",
+                    "created_at": "2020-09-24T19:07:59.311462",
+                    "created_by": "adora@example.com",
+                },
+                indent=4,
+                sort_keys=True,
+            ),
+            "email": "adora@example.com",
             "return": json.dumps(
                 {"message": "Successfully deleted 1 row"}, indent=4, sort_keys=True
             ),
         },
         {
+            "args": [
+                "template",
+                "delete_result_map_by_id",
+                "-y",
+                "cd987859-06fe-4b1a-9e96-47d4f36bf819",
+                "3d1bfbab-d9ec-46c7-aa8e-9c1d1808f2b8",
+            ],
+            "ids": [
+                "cd987859-06fe-4b1a-9e96-47d4f36bf819",
+                "3d1bfbab-d9ec-46c7-aa8e-9c1d1808f2b8",
+            ],
+            "find_return": json.dumps(
+                {
+                    "template_id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
+                    "result_id": "4d1bfbab-d9ec-46c7-aa8e-9c1d1808f2b8",
+                    "result_key": "sword_of_protection_key",
+                    "created_at": "2020-09-24T19:07:59.311462",
+                    "created_by": "adora@example.com",
+                },
+                indent=4,
+                sort_keys=True,
+            ),
+            "email": "catra@example.com",
+            "return": json.dumps(
+                {"message": "Successfully deleted 1 row"}, indent=4, sort_keys=True
+            ),
+        },
+        {
+            "args": [
+                "template",
+                "delete_result_map_by_id",
+                "cd987859-06fe-4b1a-9e96-47d4f36bf819",
+                "3d1bfbab-d9ec-46c7-aa8e-9c1d1808f2b8",
+            ],
+            "ids": [
+                "cd987859-06fe-4b1a-9e96-47d4f36bf819",
+                "3d1bfbab-d9ec-46c7-aa8e-9c1d1808f2b8",
+            ],
+            "find_return": json.dumps(
+                {
+                    "template_id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
+                    "result_id": "4d1bfbab-d9ec-46c7-aa8e-9c1d1808f2b8",
+                    "result_key": "sword_of_protection_key",
+                    "created_at": "2020-09-24T19:07:59.311462",
+                    "created_by": "adora@example.com",
+                },
+                indent=4,
+                sort_keys=True,
+            ),
+            "email": "catra@example.com",
+            "return": json.dumps(
+                {"message": "Successfully deleted 1 row"}, indent=4, sort_keys=True
+            ),
+            "interactive": {
+                "input": "y",
+                "message": "Template result mapping for template with id cd987859-06fe-4b1a-9e96-47d4f36bf819 and "
+                "result with id 3d1bfbab-d9ec-46c7-aa8e-9c1d1808f2b8 was created by adora@example.com. Are "
+                "you sure you want to delete? [y/N]: y\n",
+            },
+        },
+        {
+            "args": [
+                "template",
+                "delete_result_map_by_id",
+                "cd987859-06fe-4b1a-9e96-47d4f36bf819",
+                "3d1bfbab-d9ec-46c7-aa8e-9c1d1808f2b8",
+            ],
+            "ids": [
+                "cd987859-06fe-4b1a-9e96-47d4f36bf819",
+                "3d1bfbab-d9ec-46c7-aa8e-9c1d1808f2b8",
+            ],
+            "find_return": json.dumps(
+                {
+                    "template_id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
+                    "result_id": "4d1bfbab-d9ec-46c7-aa8e-9c1d1808f2b8",
+                    "result_key": "sword_of_protection_key",
+                    "created_at": "2020-09-24T19:07:59.311462",
+                    "created_by": "adora@example.com",
+                },
+                indent=4,
+                sort_keys=True,
+            ),
+            "email": "catra@example.com",
+            "return": "",
+            "interactive": {
+                "input": "n",
+                "message": "Template result mapping for template with id cd987859-06fe-4b1a-9e96-47d4f36bf819 and "
+                "result with id 3d1bfbab-d9ec-46c7-aa8e-9c1d1808f2b8 was created by adora@example.com. Are "
+                "you sure you want to delete? [y/N]: n",
+            },
+            "logging": "Okay, aborting delete operation",
+        },
+        {
+            "args": [
+                "template",
+                "delete_result_map_by_id",
+                "cd987859-06fe-4b1a-9e96-47d4f36bf819",
+                "3d1bfbab-d9ec-46c7-aa8e-9c1d1808f2b8",
+            ],
+            "ids": [
+                "cd987859-06fe-4b1a-9e96-47d4f36bf819",
+                "3d1bfbab-d9ec-46c7-aa8e-9c1d1808f2b8",
+            ],
+            "find_return": json.dumps(
+                {
+                    "title": "No template_result found",
+                    "status": 404,
+                    "detail": "No template_result found with the specified ID",
+                },
+                indent=4,
+                sort_keys=True,
+            ),
+            "email": "adora@example.com",
+            "return": json.dumps(
+                {
+                    "title": "No template_result found",
+                    "status": 404,
+                    "detail": "No template_result found with the specified ID",
+                },
+                indent=4,
+                sort_keys=True,
+            ),
+        },
+        {
             "args": ["template", "delete_result_map_by_id"],
-            "params": [],
+            "ids": [],
+            "email": "adora@example.com",
             "return": "Usage: carrot_cli template delete_result_map_by_id [OPTIONS] ID RESULT_ID\n"
             "Try 'carrot_cli template delete_result_map_by_id --help' for help.\n"
             "\n"
@@ -950,21 +1215,46 @@ def test_find_result_maps(find_result_maps_data):
     ]
 )
 def delete_result_map_by_id_data(request):
+    # We want to load the value from "email" from config
+    mockito.when(config).load_var("email").thenReturn(request.param["email"])
     # Set all requests to return None so only the one we expect will return a value
     mockito.when(template_results).delete_map_by_ids(...).thenReturn(None)
+    mockito.when(template_results).find_map_by_ids(...).thenReturn(None)
     # Mock up request response only if we expect it to get that far
-    if len(request.param["params"]) > 0:
+    if len(request.param["ids"]) > 0:
         mockito.when(template_results).delete_map_by_ids(
-            request.param["params"][0],
-            request.param["params"][1],
+            request.param["ids"][0],
+            request.param["ids"][1],
         ).thenReturn(request.param["return"])
+        mockito.when(template_results).find_map_by_ids(
+            request.param["ids"][0],
+            request.param["ids"][1],
+        ).thenReturn(request.param["find_return"])
     return request.param
 
 
-def test_delete_result_map_by_id(delete_result_map_by_id_data):
+def test_delete_result_map_by_id(delete_result_map_by_id_data, caplog):
+    caplog.set_level(logging.INFO)
     runner = CliRunner()
-    result = runner.invoke(carrot, delete_result_map_by_id_data["args"])
-    assert result.output == delete_result_map_by_id_data["return"] + "\n"
+    # Include interactive input and expected message if this test should trigger interactive stuff
+    if "interactive" in delete_result_map_by_id_data:
+        expected_output = (
+            delete_result_map_by_id_data["interactive"]["message"]
+            + delete_result_map_by_id_data["return"]
+            + "\n"
+        )
+        result = runner.invoke(
+            carrot,
+            delete_result_map_by_id_data["args"],
+            input=delete_result_map_by_id_data["interactive"]["input"],
+        )
+        assert result.output == expected_output
+    else:
+        result = runner.invoke(carrot, delete_result_map_by_id_data["args"])
+        assert result.output == delete_result_map_by_id_data["return"] + "\n"
+    # If we expect logging that we want to check, make sure it's there
+    if "logging" in delete_result_map_by_id_data:
+        assert delete_result_map_by_id_data["logging"] in caplog.text
 
 
 @pytest.fixture(
@@ -1195,17 +1485,123 @@ def test_find_report_maps(find_report_maps_data):
                 "cd987859-06fe-4b1a-9e96-47d4f36bf819",
                 "3d1bfbab-d9ec-46c7-aa8e-9c1d1808f2b8",
             ],
-            "params": [
+            "ids": [
                 "cd987859-06fe-4b1a-9e96-47d4f36bf819",
                 "3d1bfbab-d9ec-46c7-aa8e-9c1d1808f2b8",
             ],
+            "find_return": json.dumps(
+                {
+                    "template_id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
+                    "report_id": "3d1bfbab-d9ec-46c7-aa8e-9c1d1808f2b8",
+                    "input_map": {"section1": {"input1": "val1"}},
+                    "created_at": "2020-09-24T19:07:59.311462",
+                    "created_by": "rogelio@example.com",
+                },
+                indent=4,
+                sort_keys=True,
+            ),
+            "email": "rogelio@example.com",
             "return": json.dumps(
                 {"message": "Successfully deleted 1 row"}, indent=4, sort_keys=True
             ),
         },
         {
+            "args": [
+                "template",
+                "delete_report_map_by_id",
+                "-y",
+                "cd987859-06fe-4b1a-9e96-47d4f36bf819",
+                "3d1bfbab-d9ec-46c7-aa8e-9c1d1808f2b8",
+            ],
+            "ids": [
+                "cd987859-06fe-4b1a-9e96-47d4f36bf819",
+                "3d1bfbab-d9ec-46c7-aa8e-9c1d1808f2b8",
+            ],
+            "find_return": json.dumps(
+                {
+                    "template_id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
+                    "report_id": "3d1bfbab-d9ec-46c7-aa8e-9c1d1808f2b8",
+                    "input_map": {"section1": {"input1": "val1"}},
+                    "created_at": "2020-09-24T19:07:59.311462",
+                    "created_by": "rogelio@example.com",
+                },
+                indent=4,
+                sort_keys=True,
+            ),
+            "email": "adora@example.com",
+            "return": json.dumps(
+                {"message": "Successfully deleted 1 row"}, indent=4, sort_keys=True
+            ),
+        },
+        {
+            "args": [
+                "template",
+                "delete_report_map_by_id",
+                "cd987859-06fe-4b1a-9e96-47d4f36bf819",
+                "3d1bfbab-d9ec-46c7-aa8e-9c1d1808f2b8",
+            ],
+            "ids": [
+                "cd987859-06fe-4b1a-9e96-47d4f36bf819",
+                "3d1bfbab-d9ec-46c7-aa8e-9c1d1808f2b8",
+            ],
+            "find_return": json.dumps(
+                {
+                    "template_id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
+                    "report_id": "3d1bfbab-d9ec-46c7-aa8e-9c1d1808f2b8",
+                    "input_map": {"section1": {"input1": "val1"}},
+                    "created_at": "2020-09-24T19:07:59.311462",
+                    "created_by": "adora@example.com",
+                },
+                indent=4,
+                sort_keys=True,
+            ),
+            "email": "catra@example.com",
+            "return": json.dumps(
+                {"message": "Successfully deleted 1 row"}, indent=4, sort_keys=True
+            ),
+            "interactive": {
+                "input": "y",
+                "message": "Template report mapping for template with id cd987859-06fe-4b1a-9e96-47d4f36bf819 and "
+                "report with id 3d1bfbab-d9ec-46c7-aa8e-9c1d1808f2b8 was created by adora@example.com. Are "
+                "you sure you want to delete? [y/N]: y\n",
+            },
+        },
+        {
+            "args": [
+                "template",
+                "delete_report_map_by_id",
+                "cd987859-06fe-4b1a-9e96-47d4f36bf819",
+                "3d1bfbab-d9ec-46c7-aa8e-9c1d1808f2b8",
+            ],
+            "ids": [
+                "cd987859-06fe-4b1a-9e96-47d4f36bf819",
+                "3d1bfbab-d9ec-46c7-aa8e-9c1d1808f2b8",
+            ],
+            "find_return": json.dumps(
+                {
+                    "template_id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
+                    "report_id": "3d1bfbab-d9ec-46c7-aa8e-9c1d1808f2b8",
+                    "input_map": {"section1": {"input1": "val1"}},
+                    "created_at": "2020-09-24T19:07:59.311462",
+                    "created_by": "adora@example.com",
+                },
+                indent=4,
+                sort_keys=True,
+            ),
+            "email": "catra@example.com",
+            "return": "",
+            "interactive": {
+                "input": "n",
+                "message": "Template report mapping for template with id cd987859-06fe-4b1a-9e96-47d4f36bf819 and "
+                "report with id 3d1bfbab-d9ec-46c7-aa8e-9c1d1808f2b8 was created by adora@example.com. Are "
+                "you sure you want to delete? [y/N]: n",
+            },
+            "logging": "Okay, aborting delete operation",
+        },
+        {
             "args": ["template", "delete_report_map_by_id"],
-            "params": [],
+            "ids": [],
+            "email": "rogelio@example.com",
             "return": "Usage: carrot_cli template delete_report_map_by_id [OPTIONS] ID REPORT_ID\n"
             "Try 'carrot_cli template delete_report_map_by_id --help' for help.\n"
             "\n"
@@ -1214,18 +1610,43 @@ def test_find_report_maps(find_report_maps_data):
     ]
 )
 def delete_report_map_by_id_data(request):
+    # We want to load the value from "email" from config
+    mockito.when(config).load_var("email").thenReturn(request.param["email"])
     # Set all requests to return None so only the one we expect will return a value
     mockito.when(template_reports).delete_map_by_ids(...).thenReturn(None)
+    mockito.when(template_reports).find_map_by_ids(...).thenReturn(None)
     # Mock up request response only if we expect it to get that far
-    if len(request.param["params"]) > 0:
+    if len(request.param["ids"]) > 0:
         mockito.when(template_reports).delete_map_by_ids(
-            request.param["params"][0],
-            request.param["params"][1],
+            request.param["ids"][0],
+            request.param["ids"][1],
         ).thenReturn(request.param["return"])
+        mockito.when(template_reports).find_map_by_ids(
+            request.param["ids"][0],
+            request.param["ids"][1],
+        ).thenReturn(request.param["find_return"])
     return request.param
 
 
-def test_delete_report_map_by_id(delete_report_map_by_id_data):
+def test_delete_report_map_by_id(delete_report_map_by_id_data, caplog):
+    caplog.set_level(logging.INFO)
     runner = CliRunner()
-    result = runner.invoke(carrot, delete_report_map_by_id_data["args"])
-    assert result.output == delete_report_map_by_id_data["return"] + "\n"
+    # Include interactive input and expected message if this test should trigger interactive stuff
+    if "interactive" in delete_report_map_by_id_data:
+        expected_output = (
+            delete_report_map_by_id_data["interactive"]["message"]
+            + delete_report_map_by_id_data["return"]
+            + "\n"
+        )
+        result = runner.invoke(
+            carrot,
+            delete_report_map_by_id_data["args"],
+            input=delete_report_map_by_id_data["interactive"]["input"],
+        )
+        assert result.output == expected_output
+    else:
+        result = runner.invoke(carrot, delete_report_map_by_id_data["args"])
+        assert result.output == delete_report_map_by_id_data["return"] + "\n"
+    # If we expect logging that we want to check, make sure it's there
+    if "logging" in delete_report_map_by_id_data:
+        assert delete_report_map_by_id_data["logging"] in caplog.text

--- a/tests/unit/test/test_test_command.py
+++ b/tests/unit/test/test_test_command.py
@@ -1,4 +1,5 @@
 import json
+import logging
 
 from click.testing import CliRunner
 
@@ -366,18 +367,120 @@ def test_update(update_data):
 @pytest.fixture(
     params=[
         {
-            "args": ["run", "delete", "cd987859-06fe-4b1a-9e96-47d4f36bf819"],
+            "args": ["test", "delete", "cd987859-06fe-4b1a-9e96-47d4f36bf819"],
+            "id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
+            "find_return": json.dumps(
+                {
+                    "created_at": "2020-09-16T18:48:06.371563",
+                    "created_by": "adora@example.com",
+                    "description": "This test replaced the broken one",
+                    "test_input_defaults": {"in_greeted": "Cool Person"},
+                    "eval_input_defaults": {"in_output_filename": "test_greeting.txt"},
+                    "name": "New Sword of Protection test",
+                    "template_id": "4d1bfbab-d9ec-46c7-aa8e-9c1d1808f2b8",
+                    "test_id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
+                },
+                indent=4,
+                sort_keys=True,
+            ),
+            "email": "adora@example.com",
             "return": json.dumps(
                 {"message": "Successfully deleted 1 row"}, indent=4, sort_keys=True
             ),
         },
         {
-            "args": ["run", "delete", "cd987859-06fe-4b1a-9e96-47d4f36bf819"],
+            "args": ["test", "delete", "-y", "cd987859-06fe-4b1a-9e96-47d4f36bf819"],
+            "id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
+            "find_return": json.dumps(
+                {
+                    "created_at": "2020-09-16T18:48:06.371563",
+                    "created_by": "adora@example.com",
+                    "description": "This test replaced the broken one",
+                    "test_input_defaults": {"in_greeted": "Cool Person"},
+                    "eval_input_defaults": {"in_output_filename": "test_greeting.txt"},
+                    "name": "New Sword of Protection test",
+                    "template_id": "4d1bfbab-d9ec-46c7-aa8e-9c1d1808f2b8",
+                    "test_id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
+                },
+                indent=4,
+                sort_keys=True,
+            ),
+            "email": "catra@example.com",
+            "return": json.dumps(
+                {"message": "Successfully deleted 1 row"}, indent=4, sort_keys=True
+            ),
+        },
+        {
+            "args": ["test", "delete", "cd987859-06fe-4b1a-9e96-47d4f36bf819"],
+            "id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
+            "find_return": json.dumps(
+                {
+                    "created_at": "2020-09-16T18:48:06.371563",
+                    "created_by": "adora@example.com",
+                    "description": "This test replaced the broken one",
+                    "test_input_defaults": {"in_greeted": "Cool Person"},
+                    "eval_input_defaults": {"in_output_filename": "test_greeting.txt"},
+                    "name": "New Sword of Protection test",
+                    "template_id": "4d1bfbab-d9ec-46c7-aa8e-9c1d1808f2b8",
+                    "test_id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
+                },
+                indent=4,
+                sort_keys=True,
+            ),
+            "email": "catra@example.com",
+            "return": json.dumps(
+                {"message": "Successfully deleted 1 row"}, indent=4, sort_keys=True
+            ),
+            "interactive": {
+                "input": "y",
+                "message": "Test with id cd987859-06fe-4b1a-9e96-47d4f36bf819 was created by adora@example.com. Are "
+                "you sure you want to delete? [y/N]: y\n",
+            },
+        },
+        {
+            "args": ["test", "delete", "cd987859-06fe-4b1a-9e96-47d4f36bf819"],
+            "id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
+            "find_return": json.dumps(
+                {
+                    "created_at": "2020-09-16T18:48:06.371563",
+                    "created_by": "adora@example.com",
+                    "description": "This test replaced the broken one",
+                    "test_input_defaults": {"in_greeted": "Cool Person"},
+                    "eval_input_defaults": {"in_output_filename": "test_greeting.txt"},
+                    "name": "New Sword of Protection test",
+                    "template_id": "4d1bfbab-d9ec-46c7-aa8e-9c1d1808f2b8",
+                    "test_id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
+                },
+                indent=4,
+                sort_keys=True,
+            ),
+            "email": "catra@example.com",
+            "return": "",
+            "interactive": {
+                "input": "n",
+                "message": "Test with id cd987859-06fe-4b1a-9e96-47d4f36bf819 was created by adora@example.com. Are "
+                "you sure you want to delete? [y/N]: n",
+            },
+            "logging": "Okay, aborting delete operation",
+        },
+        {
+            "args": ["test", "delete", "cd987859-06fe-4b1a-9e96-47d4f36bf819"],
+            "id": "cd987859-06fe-4b1a-9e96-47d4f36bf819",
+            "find_return": json.dumps(
+                {
+                    "title": "No test found",
+                    "status": 404,
+                    "detail": "No test found with the specified ID",
+                },
+                indent=4,
+                sort_keys=True,
+            ),
+            "email": "adora@example.com",
             "return": json.dumps(
                 {
-                    "title": "No run found",
+                    "title": "No test found",
                     "status": 404,
-                    "detail": "No run found with the specified ID",
+                    "detail": "No test found with the specified ID",
                 },
                 indent=4,
                 sort_keys=True,
@@ -386,19 +489,37 @@ def test_update(update_data):
     ]
 )
 def delete_data(request):
+    # We want to load the value from "email" from config
+    mockito.when(config).load_var("email").thenReturn(request.param["email"])
     # Set all requests to return None so only the one we expect will return a value
-    mockito.when(runs).delete(...).thenReturn(None)
+    mockito.when(tests).delete(...).thenReturn(None)
+    mockito.when(tests).find_by_id(...).thenReturn(None)
     # Mock up request response
-    mockito.when(runs).delete(request.param["args"][2]).thenReturn(
-        request.param["return"]
+    mockito.when(tests).delete(request.param["id"]).thenReturn(request.param["return"])
+    mockito.when(tests).find_by_id(request.param["id"]).thenReturn(
+        request.param["find_return"]
     )
     return request.param
 
 
-def test_delete(delete_data):
+def test_delete(delete_data, caplog):
+    caplog.set_level(logging.INFO)
     runner = CliRunner()
-    result = runner.invoke(carrot, delete_data["args"])
-    assert result.output == delete_data["return"] + "\n"
+    # Include interactive input and expected message if this test should trigger interactive stuff
+    if "interactive" in delete_data:
+        expected_output = (
+            delete_data["interactive"]["message"] + delete_data["return"] + "\n"
+        )
+        result = runner.invoke(
+            carrot, delete_data["args"], input=delete_data["interactive"]["input"]
+        )
+        assert result.output == expected_output
+    else:
+        result = runner.invoke(carrot, delete_data["args"])
+        assert result.output == delete_data["return"] + "\n"
+    # If we expect logging that we want to check, make sure it's there
+    if "logging" in delete_data:
+        assert delete_data["logging"] in caplog.text
 
 
 @pytest.fixture(


### PR DESCRIPTION
Added a check during deletes to see who the creator of the entity is.  If the `created_by` field does not match the `email` config variable of the user, asks the user to confirm they want to delete before actually submitting the delete request.
Closes #33 