### PR TITLE
Expanded the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,35 @@
 ![CARROT CLI](https://github.com/broadinstitute/carrot_cli/blob/master/logo.png?raw=true)
 # carrot\_cli
-Command Line Interface for CARROT
+The official CLI tool for [CARROT](https://github.com/broadinstitute/carrot). This tool provides a suite of commands for interacting with the CARROT REST API.
 
 Current version: 0.3.2
 
-## Installation
+## Table of Contents
+* [Installation](#installation)
+* [Setup](#setup)
+* [Using carrot_cli](#using)
+* [Development](#development)
+    * [Linting files](#linting-files)
+    * [Tests](#tests)
+    * [Versioning](#versioning)
+
+## <a name="installation">Installation</a>
 
     pip install .
 
-## Development
+## <a name="setup">Setup</a>
+Using carrot_cli requires access to a running [CARROT](https://github.com/broadinstitute/carrot) server.  Once you have access to a server and have installed carrot_cli, there are a couple steps necessary for configuring the tool.
+1. First, configure carrot_cli to point to your CARROT server using the following command:\
+`> carrot_cli config set carrot_server_address <ADDRESS_OF_YOUR_CARROT_SERVER>`
+2. Next, configure carrot_cli to use your email address to identify you.  This will associate any data you create in CARROT with your email address and allow you to receive notifications on the status of test runs.  Do this using the following command:\
+`> carrot_cli config set email <YOUR_EMAIL>`
+
+## <a name="using">Using carrot_cli</a>
+If you are new to CARROT, start with the [User Guide](https://github.com/broadinstitute/carrot/blob/master/UserGuide.md), which provides an explanation of how CARROT works and how it should be used, along with examples using carrot_cli commands.
+
+If you would like to start with a simple example that will allow you to run a test yourself, such an example exists in the [carrot-example-test](https://github.com/broadinstitute/carrot-example-test) repo.
+
+## <a name="development">Development</a>
 
 To do development in this codebase, the python3 development package must
 be installed.
@@ -21,7 +42,7 @@ the following commands:
     pip install -r dev-requirements.txt
     pip install -e .
 
-### Linting files
+### <a name="linting-files">Linting files</a>
 
     # run all linting commands
     tox -e lint
@@ -38,7 +59,7 @@ the following commands:
     # lint python code for common errors and codestyle issues
     pylint src
 
-### Tests
+### <a name="tests">Tests</a>
 
     # run all linting and test
     tox
@@ -51,7 +72,7 @@ the following commands:
 
 Note: If you run into "module not found" errors when running tox for testing, verify the modules are listed in test-requirements.txt and delete the .tox folder to force tox to refresh dependencies.
 
-### Versioning
+### <a name="versioning">Versioning</a>
 
 We use `bumpversion` to maintain version numbers.
 DO NOT MANUALLY EDIT ANY VERSION NUMBERS.


### PR DESCRIPTION
Expanded the readme a bit to include a brief description of carrot_cli and how to configure it, along with directions pointing to the user guide and the example test repo.  Creating this PR a little earlier than I think this branch is ready to merge, because I think discussion is warranted over whether what is contained is sufficient.
For example:
- Should this repo contain its own user guide?
- Should the readme include documentation of all the commands?  Should that live somewhere else?

There's also probably plenty of room for other stuff to include that I just didn't think of.

Closes #24 